### PR TITLE
feat: add 8 new job source integrations (Tier 1 expansion)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,25 +9,31 @@
 
 ## ⭐️ Overview
 
-**Ever Jobs** searches job postings from **25 sources** concurrently and returns aggregated, normalized results through a single REST API **or CLI**. Sources span search-based job boards, ATS (Applicant Tracking System) boards, and company-specific career APIs. Each source is an independent, reusable NestJS package — making it easy to add new sources, consume individual packages in other projects, or deploy the full API.
+**Ever Jobs** searches job postings from **34 sources** concurrently and returns aggregated, normalized results through a single REST API **or CLI**. Sources span search-based job boards, ATS (Applicant Tracking System) boards, and company-specific career APIs. Each source is an independent, reusable NestJS package — making it easy to add new sources, consume individual packages in other projects, or deploy the full API.
 
-### Search-Based Job Boards (11)
+### Search-Based Job Boards (17)
 
-| Source           | Method                 | Region                      |
-| ---------------- | ---------------------- | --------------------------- |
-| **LinkedIn**     | HTML parsing (Cheerio) | Global                      |
-| **Indeed**       | GraphQL API            | 65+ countries               |
-| **Glassdoor**    | GraphQL API + CSRF     | 25+ countries               |
-| **ZipRecruiter** | REST API               | US / Canada                 |
-| **Google Jobs**  | Search page parsing    | Global                      |
-| **Bayt**         | HTML parsing (Cheerio) | Middle East / International |
-| **Naukri**       | REST API               | India                       |
-| **BDJobs**       | HTML parsing (Cheerio) | Bangladesh                  |
-| **Internshala**  | HTML parsing (Cheerio) | India (internships & jobs)  |
-| **Exa**          | Exa AI search API      | Global                      |
-| **Upwork**       | GraphQL API (OAuth2)   | Global (freelance)          |
+| Source                 | Method                 | Region                      |
+| ---------------------- | ---------------------- | --------------------------- |
+| **LinkedIn**           | HTML parsing (Cheerio) | Global                      |
+| **Indeed**             | GraphQL API            | 65+ countries               |
+| **Glassdoor**          | GraphQL API + CSRF     | 25+ countries               |
+| **ZipRecruiter**       | REST API               | US / Canada                 |
+| **Google Jobs**        | Search page parsing    | Global                      |
+| **Bayt**               | HTML parsing (Cheerio) | Middle East / International |
+| **Naukri**             | REST API               | India                       |
+| **BDJobs**             | HTML parsing (Cheerio) | Bangladesh                  |
+| **Internshala**        | HTML parsing (Cheerio) | India (internships & jobs)  |
+| **Exa**                | Exa AI search API      | Global                      |
+| **Upwork**             | GraphQL API (OAuth2)   | Global (freelance)          |
+| **RemoteOK**           | REST API (JSON)        | Global (remote)             |
+| **Remotive**           | REST API (JSON)        | Global (remote)             |
+| **Jobicy**             | REST API (JSON)        | Global (remote)             |
+| **Himalayas**          | REST API (JSON)        | Global (remote)             |
+| **Arbeitnow**          | REST API (JSON)        | Europe                      |
+| **We Work Remotely**   | RSS feed               | Global (remote)             |
 
-### ATS Job Boards (7)
+### ATS Job Boards (9)
 
 ATS scrapers require a `companySlug` to target a specific company's job board.
 
@@ -40,6 +46,8 @@ ATS scrapers require a `companySlug` to target a specific company's job board.
 | **SmartRecruiters** | SmartRecruiters | REST API    |
 | **Rippling**        | Rippling        | REST API    |
 | **Workday**         | Workday         | REST API    |
+| **Recruitee**       | Recruitee       | REST API    |
+| **Teamtailor**      | Teamtailor      | REST API    |
 
 ### Company-Specific Scrapers (7)
 
@@ -59,7 +67,7 @@ Direct integrations with major tech companies' career APIs.
 
 ## ✨ Features
 
-- 🔍 **Multi-source aggregation** — Search 1 or all 25 sources concurrently
+- 🔍 **Multi-source aggregation** — Search 1 or all 34 sources concurrently
 - 🖥️ **CLI & API** — Use via REST API or command-line with JSON, CSV, table, or summary output
 - 🌐 **Country-aware** — Indeed & Glassdoor support 65+ countries with automatic domain resolution
 - 🔄 **Proxy rotation** — Built-in rotating proxy support (HTTP, HTTPS, SOCKS5)
@@ -304,7 +312,7 @@ All parameters are optional. When `siteType` is omitted, search + company scrape
 
 | Parameter                  | Type       | Default    | Description                                                                                                                                                                                                                                                                                                                             |
 | -------------------------- | ---------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `siteType`                 | `string[]` | all        | Sites to search. **Search**: `linkedin`, `indeed`, `zip_recruiter`, `glassdoor`, `google`, `bayt`, `naukri`, `bdjobs`, `internshala`, `exa`, `upwork`. **ATS**: `ashby`, `greenhouse`, `lever`, `workable`, `smartrecruiters`, `rippling`, `workday`. **Company**: `amazon`, `apple`, `microsoft`, `nvidia`, `tiktok`, `uber`, `cursor` |
+| `siteType`                 | `string[]` | all        | Sites to search. **Search**: `linkedin`, `indeed`, `zip_recruiter`, `glassdoor`, `google`, `bayt`, `naukri`, `bdjobs`, `internshala`, `exa`, `upwork`, `remoteok`, `remotive`, `jobicy`, `himalayas`, `arbeitnow`, `weworkremotely`. **ATS**: `ashby`, `greenhouse`, `lever`, `workable`, `smartrecruiters`, `rippling`, `workday`, `recruitee`, `teamtailor`. **Company**: `amazon`, `apple`, `microsoft`, `nvidia`, `tiktok`, `uber`, `cursor` |
 | `companySlug`              | `string`   | —          | Company identifier for ATS scrapers (e.g. `stripe`, `notion`). When set without `siteType`, only ATS scrapers run                                                                                                                                                                                                                       |
 | `searchTerm`               | `string`   | —          | Job search keywords                                                                                                                                                                                                                                                                                                                     |
 | `googleSearchTerm`         | `string`   | —          | Google-specific search query override                                                                                                                                                                                                                                                                                                   |
@@ -417,8 +425,8 @@ ever-jobs/
 │   ├── models/                       @ever-jobs/models
 │   ├── common/                       @ever-jobs/common (HttpClient, converters, utils)
 │   ├── analytics/                    @ever-jobs/analytics
-│   ├── source-*/                     Search source modules (×11)
-│   ├── source-ats-*/                 ATS source modules (×7)
+│   ├── source-*/                     Search source modules (×17)
+│   ├── source-ats-*/                 ATS source modules (×9)
 │   └── source-company-*/             Company-specific source modules (×7)
 │
 ├── .github/
@@ -577,6 +585,38 @@ Global freelance marketplace. Uses the official [Upwork SDK](https://github.com/
 Get API credentials at [developers.upwork.com](https://developers.upwork.com). Without credentials, Upwork searches gracefully return empty results.
 
 Credentials can also be passed per-request via the `auth.upwork` field in the request body, which overrides env vars. See [Authentication docs](docs/AUTHENTICATION.md) for details.
+
+### RemoteOK
+
+Global remote job board with free JSON API (`remoteok.com/api`). Returns salary data when available. No authentication required.
+
+### Remotive
+
+Remote job board with free JSON API (`remotive.com/api/remote-jobs`). Supports category and search filters. Jobs are delayed 24 hours. No authentication required.
+
+### Jobicy
+
+Remote job board with free JSON API (`jobicy.com/api/v2/remote-jobs`). Provides annual salary data and supports region/industry/tag filtering. Returns up to 50 jobs per request. No authentication required.
+
+### Himalayas
+
+Remote job board with free JSON API (`himalayas.app/jobs/api`). Supports offset-based pagination (max 20 per page). No authentication required.
+
+### Arbeitnow
+
+European-focused job board with free JSON API (`arbeitnow.com/api/job-board-api`). Supports page-based pagination. No authentication required.
+
+### We Work Remotely
+
+Popular remote job board. Uses RSS feed (`weworkremotely.com/remote-jobs.rss`) — parsed without external XML libraries. Category-specific feeds also available. No authentication required.
+
+### Recruitee (ATS)
+
+Recruitee ATS integration. Per-company public API at `{slug}.recruitee.com/api/offers`. Provides salary data when available. Requires `companySlug` parameter.
+
+### Teamtailor (ATS)
+
+Teamtailor ATS integration. Per-company career page API. Requires `companySlug` parameter.
 
 ---
 

--- a/apps/api/src/jobs/jobs.module.ts
+++ b/apps/api/src/jobs/jobs.module.ts
@@ -24,6 +24,14 @@ import { NvidiaModule } from '@ever-jobs/source-company-nvidia';
 import { TikTokModule } from '@ever-jobs/source-company-tiktok';
 import { UberModule } from '@ever-jobs/source-company-uber';
 import { CursorModule } from '@ever-jobs/source-company-cursor';
+import { RemoteOkModule } from '@ever-jobs/source-remoteok';
+import { RemotiveModule } from '@ever-jobs/source-remotive';
+import { JobicyModule } from '@ever-jobs/source-jobicy';
+import { HimalayasModule } from '@ever-jobs/source-himalayas';
+import { ArbeitnowModule } from '@ever-jobs/source-arbeitnow';
+import { WeWorkRemotelyModule } from '@ever-jobs/source-weworkremotely';
+import { RecruiteeModule } from '@ever-jobs/source-ats-recruitee';
+import { TeamtailorModule } from '@ever-jobs/source-ats-teamtailor';
 import { AnalyticsModule } from '@ever-jobs/analytics';
 import { JobsController } from './jobs.controller';
 import { JobsService } from './jobs.service';
@@ -55,6 +63,14 @@ import { JobsService } from './jobs.service';
     TikTokModule,
     UberModule,
     CursorModule,
+    RemoteOkModule,
+    RemotiveModule,
+    JobicyModule,
+    HimalayasModule,
+    ArbeitnowModule,
+    WeWorkRemotelyModule,
+    RecruiteeModule,
+    TeamtailorModule,
     AnalyticsModule,
   ],
   controllers: [JobsController],

--- a/apps/api/src/jobs/jobs.service.ts
+++ b/apps/api/src/jobs/jobs.service.ts
@@ -29,6 +29,14 @@ import { NvidiaService } from '@ever-jobs/source-company-nvidia';
 import { TikTokService } from '@ever-jobs/source-company-tiktok';
 import { UberService } from '@ever-jobs/source-company-uber';
 import { CursorService } from '@ever-jobs/source-company-cursor';
+import { RemoteOkService } from '@ever-jobs/source-remoteok';
+import { RemotiveService } from '@ever-jobs/source-remotive';
+import { JobicyService } from '@ever-jobs/source-jobicy';
+import { HimalayasService } from '@ever-jobs/source-himalayas';
+import { ArbeitnowService } from '@ever-jobs/source-arbeitnow';
+import { WeWorkRemotelyService } from '@ever-jobs/source-weworkremotely';
+import { RecruiteeService } from '@ever-jobs/source-ats-recruitee';
+import { TeamtailorService } from '@ever-jobs/source-ats-teamtailor';
 
 @Injectable()
 export class JobsService {
@@ -61,6 +69,14 @@ export class JobsService {
     private readonly tiktokService: TikTokService,
     private readonly uberService: UberService,
     private readonly cursorService: CursorService,
+    private readonly remoteOkService: RemoteOkService,
+    private readonly remotiveService: RemotiveService,
+    private readonly jobicyService: JobicyService,
+    private readonly himalayasService: HimalayasService,
+    private readonly arbeitnowService: ArbeitnowService,
+    private readonly weWorkRemotelyService: WeWorkRemotelyService,
+    private readonly recruiteeService: RecruiteeService,
+    private readonly teamtailorService: TeamtailorService,
   ) {
     this.scraperMap = new Map<Site, IScraper>([
       [Site.LINKEDIN, this.linkedInService],
@@ -88,6 +104,14 @@ export class JobsService {
       [Site.TIKTOK, this.tiktokService],
       [Site.UBER, this.uberService],
       [Site.CURSOR, this.cursorService],
+      [Site.REMOTEOK, this.remoteOkService],
+      [Site.REMOTIVE, this.remotiveService],
+      [Site.JOBICY, this.jobicyService],
+      [Site.HIMALAYAS, this.himalayasService],
+      [Site.ARBEITNOW, this.arbeitnowService],
+      [Site.WEWORKREMOTELY, this.weWorkRemotelyService],
+      [Site.RECRUITEE, this.recruiteeService],
+      [Site.TEAMTAILOR, this.teamtailorService],
     ]);
   }
 
@@ -101,6 +125,8 @@ export class JobsService {
     Site.SMARTRECRUITERS,
     Site.RIPPLING,
     Site.WORKDAY,
+    Site.RECRUITEE,
+    Site.TEAMTAILOR,
   ]);
 
   /** Company scrapers target a single company's career API directly */

--- a/docs/API_CHANGELOG.md
+++ b/docs/API_CHANGELOG.md
@@ -1,5 +1,21 @@
 # API Changelog
 
+## [0.1.1] — 2026-02-14
+
+### New Sources (8)
+
+Added 8 new job source integrations (Tier 1 — public APIs/RSS, no auth required):
+
+- **Job Boards (6):** RemoteOK, Remotive, Jobicy, Himalayas, Arbeitnow, We Work Remotely
+- **ATS (2):** Recruitee, Teamtailor
+
+Total sources expanded from 26 to 34.
+
+### New `siteType` Values
+
+- `remoteok`, `remotive`, `jobicy`, `himalayas`, `arbeitnow`, `weworkremotely` — search-based job boards (included in default searches)
+- `recruitee`, `teamtailor` — ATS sources (require `companySlug` parameter)
+
 ## [0.1.0] — 2026-02-08
 
 ### New Endpoints

--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -33,7 +33,7 @@ Client Request
 │          ▼           │
 │  ┌────────────────┐  │
 │  │ Source Modules │  │   ← LinkedIn, Indeed, Glassdoor, etc.
-│  │  (25 sources)  │  │   ← search (11) + ATS (7) + company (7)
+│  │  (34 sources)  │  │   ← search (17) + ATS (9) + company (7)
 │  └────────────────┘  │
 └──────────────────────┘
            │
@@ -54,7 +54,7 @@ Client Request
 | `HealthController`    | `/health` and `/ping` endpoints                |
 | `JobsService`         | Orchestrates concurrent multi-source searching |
 | `JobsController`      | `POST /api/jobs/search` and `/analyze`         |
-| Source Modules (×25)  | Search (×11) + ATS (×7) + Company (×7)         |
+| Source Modules (×34)  | Search (×17) + ATS (×9) + Company (×7)         |
 | `AnalyticsModule`     | Job data analysis and aggregation              |
 
 ## Project Structure
@@ -75,8 +75,8 @@ ever-jobs/
 │   ├── analytics/           # Job data analytics
 │   ├── common/              # Shared HTTP client, utilities
 │   ├── models/              # TypeScript interfaces & DTOs
-│   ├── source-*/            # Search source modules (×11)
-│   ├── source-ats-*/        # ATS source modules (×7)
+│   ├── source-*/            # Search source modules (×17)
+│   ├── source-ats-*/        # ATS source modules (×9)
 │   └── source-company-*/    # Company-specific source modules (×7)
 ├── Dockerfile               # Multi-stage Docker build
 ├── docker-compose.yml       # Production deployment

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -52,3 +52,31 @@ GET /api/v1/search_jobs?search_term=developer&format=csv
 ## How does caching work?
 
 When `ENABLE_CACHE=true`, search results are cached in memory using an MD5 hash of the query parameters. Cache expires after `CACHE_EXPIRY` seconds (default 3600). Cached responses include `"cached": true`.
+
+## How many job sources are supported?
+
+Currently **34 sources**: 17 search-based job boards, 9 ATS integrations, and 7 company-specific scrapers. See the [README](../README.md) for the full list.
+
+## How do I search remote job boards?
+
+The remote-focused job boards (RemoteOK, Remotive, Jobicy, Himalayas, Arbeitnow, We Work Remotely) are included in default searches automatically. You can also target them specifically:
+
+```bash
+npm run cli -- search --search-term "typescript" --site remoteok --site remotive --site jobicy
+```
+
+## How do I use the new ATS sources (Recruitee, Teamtailor)?
+
+Like all ATS scrapers, they require a `companySlug` parameter:
+
+```bash
+# Search a specific company's Recruitee board
+npm run cli -- search --company-slug "mycompany" --site recruitee
+
+# Search a specific company's Teamtailor board
+npm run cli -- search --company-slug "mycompany" --site teamtailor
+```
+
+## What remote job boards have salary data?
+
+RemoteOK and Jobicy provide salary information in their APIs. Remotive includes salary as a text field. Himalayas includes min/max salary when available. For other sources, the salary enrichment pipeline attempts to extract salary from job descriptions.

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -9,6 +9,9 @@
 | **Docker Compose**    | Tool for defining and running multi-container Docker applications    |
 | **Swagger / OpenAPI** | Standard for describing REST APIs; used for interactive docs         |
 | **Source Module**     | Module that fetches job listings from a specific job board           |
+| **ATS**               | Applicant Tracking System — software companies use to manage hiring  |
+| **RSS**               | Really Simple Syndication — XML-based feed format for content updates|
+| **companySlug**       | Company identifier used by ATS sources to target a specific board    |
 | **TTL**               | Time-to-live — how long cached data remains valid                    |
 | **Guard**             | NestJS mechanism for request authentication/authorization            |
 | **Interceptor**       | NestJS mechanism for transforming requests/responses                 |

--- a/docs/PRD_NEW_JOB_SOURCES.md
+++ b/docs/PRD_NEW_JOB_SOURCES.md
@@ -1,0 +1,238 @@
+# PRD: Expand Job Source Coverage
+
+**Author:** AI Assistant
+**Date:** 2026-02-14
+**Status:** In Progress
+**Epic:** Source Expansion
+
+---
+
+## 1. Overview
+
+Expand ever-jobs from **26 sources** to **34+ sources** by adding new job boards and ATS integrations. This PRD covers the first tier of easy-to-integrate sources that have public APIs or RSS feeds requiring no authentication.
+
+### Current Sources (26)
+
+| Category | Sources |
+|----------|---------|
+| **Job Boards (9)** | LinkedIn, Indeed, Glassdoor, ZipRecruiter, Google, Bayt, Naukri, BDJobs, Internshala |
+| **API/Aggregation (2)** | Exa, Upwork |
+| **ATS (7)** | Ashby, Greenhouse, Lever, Workable, SmartRecruiters, Rippling, Workday |
+| **Company (7)** | Amazon, Apple, Microsoft, Nvidia, TikTok, Uber, Cursor |
+
+---
+
+## 2. Tier 1 - Public API / RSS (This Phase)
+
+These 8 sources have free, unauthenticated APIs or RSS feeds. They follow existing patterns closely and can be integrated with minimal risk.
+
+### 2.1 RemoteOK
+
+| Field | Value |
+|-------|-------|
+| **Type** | Job Board (remote-focused) |
+| **API** | `GET https://remoteok.com/api` |
+| **Auth** | None |
+| **Format** | JSON array |
+| **Volume** | ~30,000+ remote listings |
+| **Package** | `source-remoteok` |
+| **Site Enum** | `REMOTEOK` |
+| **Notes** | First element is metadata (skip). Fields: `slug`, `company`, `position`, `description`, `location`, `salary_min`, `salary_max`, `url`, `date`. Must attribute back to RemoteOK. |
+
+### 2.2 Remotive
+
+| Field | Value |
+|-------|-------|
+| **Type** | Job Board (remote-focused) |
+| **API** | `GET https://remotive.com/api/remote-jobs` |
+| **Auth** | None |
+| **Format** | JSON `{ jobs: [...] }` |
+| **Volume** | Thousands of remote listings |
+| **Package** | `source-remotive` |
+| **Site Enum** | `REMOTIVE` |
+| **Notes** | Params: `category`, `search`, `limit`. Fields: `id`, `url`, `title`, `company_name`, `category`, `publication_date`, `candidate_required_location`, `salary`, `description`. Jobs delayed 24h. |
+
+### 2.3 Jobicy
+
+| Field | Value |
+|-------|-------|
+| **Type** | Job Board (remote-focused) |
+| **API** | `GET https://jobicy.com/api/v2/remote-jobs` |
+| **Auth** | None |
+| **Format** | JSON `{ jobs: [...] }` |
+| **Volume** | Latest 50 per request |
+| **Package** | `source-jobicy` |
+| **Site Enum** | `JOBICY` |
+| **Notes** | Params: `count` (1-50), `geo` (region filter), `industry`, `tag`. Fields: `id`, `url`, `jobTitle`, `companyName`, `companyLogo`, `jobIndustry`, `jobType`, `jobGeo`, `jobLevel`, `jobExcerpt`, `pubDate`, `annualSalaryMin`, `annualSalaryMax`, `salaryCurrency`. 6h cache. |
+
+### 2.4 Himalayas
+
+| Field | Value |
+|-------|-------|
+| **Type** | Job Board (remote-focused) |
+| **API** | `GET https://himalayas.app/jobs/api` |
+| **Auth** | None |
+| **Format** | JSON `{ jobs: [...], ... }` |
+| **Volume** | Max 20 per request with offset pagination |
+| **Package** | `source-himalayas` |
+| **Site Enum** | `HIMALAYAS` |
+| **Notes** | Params: `limit` (max 20), `offset`. Fields: `id`, `title`, `companyName`, `categories`, `locationRestrictions`, `url`, `description`, `pubDate`, `salary`, `seniority`. Rate limited. |
+
+### 2.5 Arbeitnow
+
+| Field | Value |
+|-------|-------|
+| **Type** | Job Board (European focus) |
+| **API** | `GET https://www.arbeitnow.com/api/job-board-api` |
+| **Auth** | None |
+| **Format** | JSON `{ data: [...], ... }` |
+| **Volume** | Paginated |
+| **Package** | `source-arbeitnow` |
+| **Site Enum** | `ARBEITNOW` |
+| **Notes** | Params: `page`. Fields: `slug`, `company_name`, `title`, `description`, `remote`, `url`, `tags`, `job_types`, `location`, `created_at`. European jobs focus. Cursor pagination via `links.next`. |
+
+### 2.6 We Work Remotely
+
+| Field | Value |
+|-------|-------|
+| **Type** | Job Board (remote-focused) |
+| **API** | RSS `https://weworkremotely.com/remote-jobs.rss` |
+| **Auth** | None |
+| **Format** | XML/RSS |
+| **Volume** | Top listings |
+| **Package** | `source-weworkremotely` |
+| **Site Enum** | `WEWORKREMOTELY` |
+| **Notes** | Category-specific feeds: `/categories/remote-[category]-jobs.rss`. Uses standard RSS items with `title`, `link`, `description`, `pubDate`, `company`. Must attribute. Requires XML parsing (e.g. `fast-xml-parser`). |
+
+### 2.7 Recruitee (ATS)
+
+| Field | Value |
+|-------|-------|
+| **Type** | ATS |
+| **API** | `GET https://{companySlug}.recruitee.com/api/offers` |
+| **Auth** | None |
+| **Format** | JSON `{ offers: [...] }` |
+| **Package** | `source-ats-recruitee` |
+| **Site Enum** | `RECRUITEE` |
+| **Notes** | Per-company endpoints like existing ATS sources. Fields: `id`, `title`, `slug`, `department`, `location`, `city`, `country`, `state`, `remote`, `description`, `created_at`, `careers_url`, `min_hours`, `max_hours`, `salary_min`, `salary_max`, `salary_currency`. Requires `companySlug`. |
+
+### 2.8 Teamtailor (ATS)
+
+| Field | Value |
+|-------|-------|
+| **Type** | ATS |
+| **API** | `GET https://career.{companyDomain}/connect/jobs` (JSON-API) |
+| **Auth** | None (public career site) |
+| **Format** | JSON-API |
+| **Package** | `source-ats-teamtailor` |
+| **Site Enum** | `TEAMTAILOR` |
+| **Notes** | Career pages hosted at `career.{company}.com` or custom domains. Job listings available via public career page API. Fields vary by company config. Also supports `/{company}/jobs` pattern on `https://career.teamtailor.com`. Requires `companySlug`. |
+
+---
+
+## 3. Future Tiers (Planned)
+
+### Tier 1.5 - Free API Key Required
+
+| Source | Type | Notes |
+|--------|------|-------|
+| USAJobs | Job Board | US government jobs, free API key |
+| Adzuna | Aggregator | 16+ countries, free API key |
+| Reed | Job Board | UK-focused, free API key |
+| Jooble | Aggregator | Free developer API |
+| CareerJet | Aggregator | Free webmaster API |
+
+### Tier 2 - HTML Scraping (Medium)
+
+| Source | Type | Notes |
+|--------|------|-------|
+| Wellfound (AngelList) | Job Board | Startups, salary/equity |
+| StepStone | Job Board | Major European board |
+| Dice | Job Board | Tech-focused, 70K+ jobs |
+| SimplyHired | Job Board | Standard HTML |
+| JazzHR | ATS | Clean career pages |
+| Personio | ATS | European HR platform |
+| BambooHR | ATS | Per-company API |
+| Comeet | ATS | Clean HTML |
+| Pinpoint | ATS | Clean HTML |
+
+### Tier 3 - Heavy Anti-Bot (Hard)
+
+| Source | Type | Notes |
+|--------|------|-------|
+| Monster | Job Board | DataDome protection |
+| CareerBuilder | Job Board | Moderate-heavy protection |
+| iCIMS | ATS | Enterprise, JS rendering |
+| Oracle Taleo | ATS | Legacy, complex URLs |
+| SAP SuccessFactors | ATS | Enterprise |
+| Phenom People | ATS | AI-powered, heavy JS |
+| Eightfold | ATS | AI-powered, heavy JS |
+
+---
+
+## 4. Technical Design
+
+### Package Structure (per source)
+
+```
+packages/source-{name}/
+  package.json
+  tsconfig.json
+  src/
+    index.ts
+    {name}.module.ts
+    {name}.service.ts
+    {name}.constants.ts
+    {name}.types.ts
+```
+
+### Integration Points
+
+1. **`packages/models/src/enums/site.enum.ts`** - Add enum values
+2. **`tsconfig.base.json`** - Add path mappings
+3. **`apps/api/src/jobs/jobs.module.ts`** - Import modules
+4. **`apps/api/src/jobs/jobs.service.ts`** - Wire services into scraperMap
+5. **`JobsService.ATS_SITES`** - Add ATS sources (Recruitee, Teamtailor)
+6. **`JobsService.COMPANY_SITES`** - No changes for this tier
+
+### Shared Dependencies
+
+All sources use existing shared packages:
+- `@ever-jobs/models` - DTOs, enums, interfaces
+- `@ever-jobs/common` - HTTP client, utilities
+
+New dependency for RSS parsing:
+- `fast-xml-parser` - For WeWorkRemotely RSS feed
+
+### Data Flow
+
+```
+API Request
+  -> JobsService.searchJobs()
+    -> scraperMap.get(site).scrape(input)
+      -> Source fetches from external API/RSS
+      -> Maps response to JobPostDto[]
+    -> Post-process salary
+    -> Sort & return
+```
+
+---
+
+## 5. Success Criteria
+
+- All 8 new sources return valid `JobPostDto[]` when their APIs are reachable
+- Existing sources remain unaffected
+- TypeScript compiles without errors
+- Each source handles API errors gracefully (returns empty array)
+- Sources categorized correctly (job boards vs ATS)
+
+---
+
+## 6. Rollout Plan
+
+| Phase | Sources | Status |
+|-------|---------|--------|
+| **Phase 1 (Tier 1)** | RemoteOK, Remotive, Jobicy, Himalayas, Arbeitnow, WeWorkRemotely, Recruitee, Teamtailor | **In Progress** |
+| **Phase 2 (Tier 1.5)** | USAJobs, Adzuna, Reed, Jooble, CareerJet | Planned |
+| **Phase 3 (Tier 2)** | Wellfound, StepStone, Dice, SimplyHired, JazzHR, Personio, BambooHR | Planned |
+| **Phase 4 (Tier 3)** | Monster, CareerBuilder, iCIMS, Taleo, SuccessFactors | Planned |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,7 +2,7 @@
 
 ## Current (v0.1.x)
 
-- ✅ Multi-source job searching (11 boards)
+- ✅ Multi-source job searching (34 sources)
 - ✅ API key authentication
 - ✅ Rate limiting
 - ✅ In-memory caching
@@ -11,17 +11,23 @@
 - ✅ Docker deployment
 - ✅ Swagger / OpenAPI docs
 - ✅ CLI application
+- ✅ ATS integrations (Ashby, Greenhouse, Lever, Workable, SmartRecruiters, Rippling, Workday, Recruitee, Teamtailor)
+- ✅ Company-specific scrapers (Amazon, Apple, Microsoft, Nvidia, TikTok, Uber, Cursor)
+- ✅ Remote job boards (RemoteOK, Remotive, Jobicy, Himalayas, Arbeitnow, We Work Remotely)
 
 ## Planned (v0.2.0)
 
+- Additional sources: USAJobs, Adzuna, Reed, Jooble, CareerJet (Tier 1.5 — free API key required)
 - Redis-backed caching (scalable, persistent)
 - WebSocket / SSE support for real-time search progress
 - Job deduplication across sources
 - Configurable retry policies per source
 - Prometheus metrics endpoint (`/metrics`)
 
-## Future Considerations
+## Future Considerations (v0.3.0+)
 
+- Tier 2 sources: Wellfound (AngelList), StepStone, Dice, SimplyHired, JazzHR, Personio, BambooHR
+- Tier 3 sources: Monster, CareerBuilder, iCIMS, Oracle Taleo, SAP SuccessFactors
 - GraphQL API alongside REST
 - OAuth2 authentication
 - Frontend dashboard for job search results

--- a/packages/models/src/enums/site.enum.ts
+++ b/packages/models/src/enums/site.enum.ts
@@ -24,6 +24,14 @@ export enum Site {
   TIKTOK = 'tiktok',
   UBER = 'uber',
   CURSOR = 'cursor',
+  JOBICY = 'jobicy',
+  HIMALAYAS = 'himalayas',
+  REMOTEOK = 'remoteok',
+  REMOTIVE = 'remotive',
+  RECRUITEE = 'recruitee',
+  TEAMTAILOR = 'teamtailor',
+  ARBEITNOW = 'arbeitnow',
+  WEWORKREMOTELY = 'weworkremotely',
 }
 
 /**

--- a/packages/source-arbeitnow/package.json
+++ b/packages/source-arbeitnow/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@ever-jobs/source-arbeitnow",
+  "version": "0.1.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "MIT"
+}

--- a/packages/source-arbeitnow/src/arbeitnow.constants.ts
+++ b/packages/source-arbeitnow/src/arbeitnow.constants.ts
@@ -1,0 +1,5 @@
+export const ARBEITNOW_API_URL = 'https://www.arbeitnow.com/api/job-board-api';
+export const ARBEITNOW_HEADERS: Record<string, string> = {
+  Accept: 'application/json',
+  'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129 Safari/537.36',
+};

--- a/packages/source-arbeitnow/src/arbeitnow.module.ts
+++ b/packages/source-arbeitnow/src/arbeitnow.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { ArbeitnowService } from './arbeitnow.service';
+
+@Module({
+  providers: [ArbeitnowService],
+  exports: [ArbeitnowService],
+})
+export class ArbeitnowModule {}

--- a/packages/source-arbeitnow/src/arbeitnow.service.ts
+++ b/packages/source-arbeitnow/src/arbeitnow.service.ts
@@ -14,6 +14,7 @@ import {
 import {
   createHttpClient,
   htmlToPlainText,
+  markdownConverter,
   extractEmails,
 } from '@ever-jobs/common';
 import { ARBEITNOW_API_URL, ARBEITNOW_HEADERS } from './arbeitnow.constants';
@@ -115,10 +116,14 @@ export class ArbeitnowService implements IScraper {
   ): JobPostDto | null {
     if (!raw.title || !raw.url) return null;
 
-    // Process description (HTML from API)
+    // Process description (Arbeitnow returns HTML)
     let description: string | null = raw.description ?? null;
-    if (description && descriptionFormat === DescriptionFormat.PLAIN) {
-      description = htmlToPlainText(description);
+    if (description) {
+      if (descriptionFormat === DescriptionFormat.PLAIN) {
+        description = htmlToPlainText(description);
+      } else if (descriptionFormat === DescriptionFormat.MARKDOWN) {
+        description = markdownConverter(description) ?? description;
+      }
     }
 
     // Build location

--- a/packages/source-arbeitnow/src/arbeitnow.service.ts
+++ b/packages/source-arbeitnow/src/arbeitnow.service.ts
@@ -1,0 +1,164 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  IScraper,
+  ScraperInputDto,
+  JobResponseDto,
+  JobPostDto,
+  LocationDto,
+  CompensationDto,
+  Site,
+  DescriptionFormat,
+  JobType,
+  getJobTypeFromString,
+} from '@ever-jobs/models';
+import {
+  createHttpClient,
+  htmlToPlainText,
+  extractEmails,
+} from '@ever-jobs/common';
+import { ARBEITNOW_API_URL, ARBEITNOW_HEADERS } from './arbeitnow.constants';
+import { ArbeitnowJob, ArbeitnowApiResponse } from './arbeitnow.types';
+
+/** Maximum number of pages to fetch to avoid excessive requests. */
+const MAX_PAGES = 3;
+
+@Injectable()
+export class ArbeitnowService implements IScraper {
+  private readonly logger = new Logger(ArbeitnowService.name);
+
+  async scrape(input: ScraperInputDto): Promise<JobResponseDto> {
+    const resultsWanted = input.resultsWanted ?? 25;
+
+    const client = createHttpClient({
+      proxies: input.proxies,
+      caCert: input.caCert,
+      timeout: input.requestTimeout,
+    });
+    client.setHeaders(ARBEITNOW_HEADERS);
+
+    const jobs: JobPostDto[] = [];
+    let page = 1;
+
+    this.logger.log(
+      `Fetching Arbeitnow jobs (resultsWanted=${resultsWanted})`,
+    );
+
+    try {
+      while (jobs.length < resultsWanted && page <= MAX_PAGES) {
+        this.logger.log(`Fetching Arbeitnow page ${page}`);
+
+        const response = await client.get<ArbeitnowApiResponse>(
+          ARBEITNOW_API_URL,
+          { params: { page } },
+        );
+
+        const rawJobs = response.data?.data ?? [];
+        if (rawJobs.length === 0) {
+          this.logger.log('No more jobs returned from Arbeitnow');
+          break;
+        }
+
+        for (const raw of rawJobs) {
+          if (jobs.length >= resultsWanted) break;
+
+          try {
+            // Filter by search term if provided
+            if (input.searchTerm && !this.matchesSearch(raw, input.searchTerm)) {
+              continue;
+            }
+
+            const job = this.mapJob(raw, input.descriptionFormat);
+            if (job) jobs.push(job);
+          } catch (err: any) {
+            this.logger.warn(
+              `Error mapping Arbeitnow job ${raw.slug}: ${err.message}`,
+            );
+          }
+        }
+
+        // Check if there are more pages
+        const hasNext = response.data?.links?.next != null;
+        if (!hasNext) break;
+
+        page++;
+      }
+    } catch (err: any) {
+      this.logger.error(`Arbeitnow scrape error: ${err.message}`);
+    }
+
+    this.logger.log(`Arbeitnow returned ${jobs.length} jobs`);
+    return new JobResponseDto(jobs);
+  }
+
+  /**
+   * Check whether a job matches the given search term.
+   */
+  private matchesSearch(raw: ArbeitnowJob, searchTerm: string): boolean {
+    const term = searchTerm.toLowerCase();
+    const title = (raw.title ?? '').toLowerCase();
+    const tags = (raw.tags ?? []).map((t) => t.toLowerCase()).join(' ');
+    const description = (raw.description ?? '').toLowerCase();
+
+    return (
+      title.includes(term) ||
+      tags.includes(term) ||
+      description.includes(term)
+    );
+  }
+
+  /**
+   * Map a raw Arbeitnow job to a JobPostDto.
+   */
+  private mapJob(
+    raw: ArbeitnowJob,
+    descriptionFormat?: DescriptionFormat,
+  ): JobPostDto | null {
+    if (!raw.title || !raw.url) return null;
+
+    // Process description (HTML from API)
+    let description: string | null = raw.description ?? null;
+    if (description && descriptionFormat === DescriptionFormat.PLAIN) {
+      description = htmlToPlainText(description);
+    }
+
+    // Build location
+    const location = new LocationDto({
+      city: raw.location ?? null,
+    });
+
+    // Parse date from Unix timestamp
+    let datePosted: string | null = null;
+    if (raw.created_at) {
+      try {
+        datePosted = new Date(raw.created_at * 1000)
+          .toISOString()
+          .split('T')[0];
+      } catch {
+        datePosted = null;
+      }
+    }
+
+    // Map job type from job_types array
+    const jobType: JobType[] | null =
+      raw.job_types && raw.job_types.length > 0
+        ? raw.job_types
+            .map((t) => getJobTypeFromString(t))
+            .filter((t): t is JobType => t !== null)
+        : null;
+
+    return new JobPostDto({
+      id: `arbeitnow-${raw.slug}`,
+      title: raw.title,
+      companyName: raw.company_name ?? null,
+      jobUrl: raw.url,
+      location,
+      description,
+      compensation: null,
+      datePosted,
+      jobType,
+      isRemote: raw.remote ?? false,
+      emails: extractEmails(description),
+      site: Site.ARBEITNOW,
+    });
+  }
+}

--- a/packages/source-arbeitnow/src/arbeitnow.types.ts
+++ b/packages/source-arbeitnow/src/arbeitnow.types.ts
@@ -1,0 +1,26 @@
+/**
+ * Shape of a single job returned by the Arbeitnow API.
+ */
+export interface ArbeitnowJob {
+  slug: string;
+  company_name: string;
+  title: string;
+  description: string;
+  remote: boolean;
+  url: string;
+  tags: string[];
+  job_types: string[];
+  location: string;
+  created_at: number;
+}
+
+/**
+ * Top-level response envelope from the Arbeitnow API.
+ */
+export interface ArbeitnowApiResponse {
+  data: ArbeitnowJob[];
+  links: {
+    next: string | null;
+  };
+  meta: Record<string, any>;
+}

--- a/packages/source-arbeitnow/src/index.ts
+++ b/packages/source-arbeitnow/src/index.ts
@@ -1,0 +1,2 @@
+export { ArbeitnowModule } from './arbeitnow.module';
+export { ArbeitnowService } from './arbeitnow.service';

--- a/packages/source-arbeitnow/tsconfig.json
+++ b/packages/source-arbeitnow/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../dist/packages/source-arbeitnow",
+    "declaration": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/source-ats-recruitee/package.json
+++ b/packages/source-ats-recruitee/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@ever-jobs/source-ats-recruitee",
+  "version": "0.1.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "MIT"
+}

--- a/packages/source-ats-recruitee/src/index.ts
+++ b/packages/source-ats-recruitee/src/index.ts
@@ -1,0 +1,2 @@
+export { RecruiteeModule } from './recruitee.module';
+export { RecruiteeService } from './recruitee.service';

--- a/packages/source-ats-recruitee/src/recruitee.constants.ts
+++ b/packages/source-ats-recruitee/src/recruitee.constants.ts
@@ -1,0 +1,9 @@
+/** Recruitee API base URL (slug is interpolated at runtime) */
+export const RECRUITEE_API_BASE = 'https://{slug}.recruitee.com/api/offers';
+
+/** Default headers for Recruitee API requests */
+export const RECRUITEE_HEADERS: Record<string, string> = {
+  Accept: 'application/json',
+  'User-Agent':
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129 Safari/537.36',
+};

--- a/packages/source-ats-recruitee/src/recruitee.module.ts
+++ b/packages/source-ats-recruitee/src/recruitee.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { RecruiteeService } from './recruitee.service';
+
+@Module({
+  providers: [RecruiteeService],
+  exports: [RecruiteeService],
+})
+export class RecruiteeModule {}

--- a/packages/source-ats-recruitee/src/recruitee.service.ts
+++ b/packages/source-ats-recruitee/src/recruitee.service.ts
@@ -1,0 +1,145 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  IScraper,
+  ScraperInputDto,
+  JobResponseDto,
+  JobPostDto,
+  LocationDto,
+  CompensationDto,
+  CompensationInterval,
+  Site,
+  DescriptionFormat,
+} from '@ever-jobs/models';
+import {
+  createHttpClient,
+  htmlToPlainText,
+  extractEmails,
+} from '@ever-jobs/common';
+import { RECRUITEE_HEADERS } from './recruitee.constants';
+import { RecruiteeOffer, RecruiteeResponse } from './recruitee.types';
+
+@Injectable()
+export class RecruiteeService implements IScraper {
+  private readonly logger = new Logger(RecruiteeService.name);
+
+  async scrape(input: ScraperInputDto): Promise<JobResponseDto> {
+    const companySlug = input.companySlug;
+    if (!companySlug) {
+      this.logger.warn('No companySlug provided for Recruitee scraper');
+      return new JobResponseDto([]);
+    }
+
+    const client = createHttpClient({
+      proxies: input.proxies,
+      caCert: input.caCert,
+      timeout: input.requestTimeout,
+    });
+    client.setHeaders(RECRUITEE_HEADERS);
+
+    const url = `https://${encodeURIComponent(companySlug)}.recruitee.com/api/offers`;
+
+    try {
+      this.logger.log(`Fetching Recruitee jobs for company: ${companySlug}`);
+      const response = await client.get(url);
+      const data: RecruiteeResponse = response.data ?? { offers: [] };
+      const offers = data.offers ?? [];
+
+      this.logger.log(`Recruitee: found ${offers.length} raw jobs for ${companySlug}`);
+
+      const resultsWanted = input.resultsWanted ?? 100;
+      const jobPosts: JobPostDto[] = [];
+
+      for (const offer of offers) {
+        if (jobPosts.length >= resultsWanted) break;
+
+        try {
+          const post = this.processOffer(offer, companySlug, input.descriptionFormat);
+          if (post) {
+            jobPosts.push(post);
+          }
+        } catch (err: any) {
+          this.logger.warn(`Error processing Recruitee offer ${offer.id}: ${err.message}`);
+        }
+      }
+
+      return new JobResponseDto(jobPosts);
+    } catch (err: any) {
+      this.logger.error(`Recruitee scrape error for ${companySlug}: ${err.message}`);
+      return new JobResponseDto([]);
+    }
+  }
+
+  private processOffer(
+    offer: RecruiteeOffer,
+    companySlug: string,
+    format?: DescriptionFormat,
+  ): JobPostDto | null {
+    const title = offer.title;
+    if (!title) return null;
+
+    // Description is HTML
+    let description: string | null = null;
+    if (offer.description) {
+      if (format === DescriptionFormat.HTML) {
+        description = offer.description;
+      } else {
+        description = htmlToPlainText(offer.description);
+      }
+    }
+
+    // Location from city/state/country fields
+    const location = new LocationDto({
+      city: offer.city ?? null,
+      state: offer.state ?? null,
+      country: offer.country ?? null,
+    });
+
+    // Compensation from salary_min/salary_max
+    const compensation = this.extractCompensation(offer);
+
+    // Job URL from careers_url + slug
+    const jobUrl = offer.careers_url && offer.slug
+      ? `${offer.careers_url}/${offer.slug}`
+      : `https://${companySlug}.recruitee.com/o/${offer.slug ?? offer.id}`;
+
+    // Date posted
+    const datePosted = offer.created_at
+      ? new Date(offer.created_at).toISOString().split('T')[0]
+      : null;
+
+    return new JobPostDto({
+      id: `recruitee-${offer.id}`,
+      title,
+      companyName: companySlug,
+      jobUrl,
+      location,
+      description,
+      compensation,
+      datePosted,
+      isRemote: offer.remote ?? false,
+      emails: extractEmails(description),
+      site: Site.RECRUITEE,
+      // ATS-specific fields
+      atsId: String(offer.id),
+      atsType: 'recruitee',
+      department: offer.department ?? null,
+    });
+  }
+
+  /**
+   * Extract compensation from Recruitee salary fields.
+   * Skips if both salary_min and salary_max are null.
+   */
+  private extractCompensation(offer: RecruiteeOffer): CompensationDto | null {
+    if (offer.salary_min == null && offer.salary_max == null) {
+      return null;
+    }
+
+    return new CompensationDto({
+      interval: CompensationInterval.YEARLY,
+      minAmount: offer.salary_min ?? undefined,
+      maxAmount: offer.salary_max ?? undefined,
+      currency: offer.salary_currency ?? 'USD',
+    });
+  }
+}

--- a/packages/source-ats-recruitee/src/recruitee.service.ts
+++ b/packages/source-ats-recruitee/src/recruitee.service.ts
@@ -13,6 +13,7 @@ import {
 import {
   createHttpClient,
   htmlToPlainText,
+  markdownConverter,
   extractEmails,
 } from '@ever-jobs/common';
 import { RECRUITEE_HEADERS } from './recruitee.constants';
@@ -82,6 +83,8 @@ export class RecruiteeService implements IScraper {
     if (offer.description) {
       if (format === DescriptionFormat.HTML) {
         description = offer.description;
+      } else if (format === DescriptionFormat.MARKDOWN) {
+        description = markdownConverter(offer.description) ?? offer.description;
       } else {
         description = htmlToPlainText(offer.description);
       }

--- a/packages/source-ats-recruitee/src/recruitee.types.ts
+++ b/packages/source-ats-recruitee/src/recruitee.types.ts
@@ -1,0 +1,27 @@
+/**
+ * TypeScript interfaces for Recruitee API responses.
+ */
+
+export interface RecruiteeResponse {
+  offers: RecruiteeOffer[];
+}
+
+export interface RecruiteeOffer {
+  id: number;
+  title: string;
+  slug: string;
+  department: string | null;
+  location: string | null;
+  city: string | null;
+  country: string | null;
+  state: string | null;
+  remote: boolean;
+  description: string;
+  created_at: string;
+  careers_url: string;
+  min_hours: number | null;
+  max_hours: number | null;
+  salary_min: number | null;
+  salary_max: number | null;
+  salary_currency: string | null;
+}

--- a/packages/source-ats-recruitee/tsconfig.json
+++ b/packages/source-ats-recruitee/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../dist/packages/source-ats-recruitee",
+    "declaration": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/source-ats-teamtailor/package.json
+++ b/packages/source-ats-teamtailor/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@ever-jobs/source-ats-teamtailor",
+  "version": "0.1.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "MIT"
+}

--- a/packages/source-ats-teamtailor/src/index.ts
+++ b/packages/source-ats-teamtailor/src/index.ts
@@ -1,0 +1,2 @@
+export { TeamtailorModule } from './teamtailor.module';
+export { TeamtailorService } from './teamtailor.service';

--- a/packages/source-ats-teamtailor/src/teamtailor.constants.ts
+++ b/packages/source-ats-teamtailor/src/teamtailor.constants.ts
@@ -1,0 +1,9 @@
+/** Teamtailor widget API base URL */
+export const TEAMTAILOR_API_URL = 'https://career.teamtailor.com/widget/jobs';
+
+/** Default headers for Teamtailor API requests */
+export const TEAMTAILOR_HEADERS: Record<string, string> = {
+  Accept: 'application/json',
+  'User-Agent':
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129 Safari/537.36',
+};

--- a/packages/source-ats-teamtailor/src/teamtailor.module.ts
+++ b/packages/source-ats-teamtailor/src/teamtailor.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { TeamtailorService } from './teamtailor.service';
+
+@Module({
+  providers: [TeamtailorService],
+  exports: [TeamtailorService],
+})
+export class TeamtailorModule {}

--- a/packages/source-ats-teamtailor/src/teamtailor.service.ts
+++ b/packages/source-ats-teamtailor/src/teamtailor.service.ts
@@ -1,0 +1,137 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  IScraper,
+  ScraperInputDto,
+  JobResponseDto,
+  JobPostDto,
+  LocationDto,
+  Site,
+  DescriptionFormat,
+} from '@ever-jobs/models';
+import {
+  createHttpClient,
+  htmlToPlainText,
+  extractEmails,
+} from '@ever-jobs/common';
+import { TEAMTAILOR_API_URL, TEAMTAILOR_HEADERS } from './teamtailor.constants';
+import { TeamtailorJob, TeamtailorResponse } from './teamtailor.types';
+
+@Injectable()
+export class TeamtailorService implements IScraper {
+  private readonly logger = new Logger(TeamtailorService.name);
+
+  async scrape(input: ScraperInputDto): Promise<JobResponseDto> {
+    const companySlug = input.companySlug;
+    if (!companySlug) {
+      this.logger.warn('No companySlug provided for Teamtailor scraper');
+      return new JobResponseDto([]);
+    }
+
+    const client = createHttpClient({
+      proxies: input.proxies,
+      caCert: input.caCert,
+      timeout: input.requestTimeout,
+    });
+    client.setHeaders(TEAMTAILOR_HEADERS);
+
+    const url = `${TEAMTAILOR_API_URL}/${encodeURIComponent(companySlug)}`;
+
+    try {
+      this.logger.log(`Fetching Teamtailor jobs for company: ${companySlug}`);
+      const response = await client.get(url);
+      const data: TeamtailorResponse = response.data ?? { data: [] };
+      const jobs = data.data ?? [];
+
+      if (!Array.isArray(jobs)) {
+        this.logger.warn(`Unexpected Teamtailor response format for ${companySlug}`);
+        return new JobResponseDto([]);
+      }
+
+      this.logger.log(`Teamtailor: found ${jobs.length} raw jobs for ${companySlug}`);
+
+      const resultsWanted = input.resultsWanted ?? 100;
+      const jobPosts: JobPostDto[] = [];
+
+      for (const job of jobs) {
+        if (jobPosts.length >= resultsWanted) break;
+
+        try {
+          const post = this.processJob(job, companySlug, input.descriptionFormat);
+          if (post) {
+            jobPosts.push(post);
+          }
+        } catch (err: any) {
+          this.logger.warn(`Error processing Teamtailor job ${job.id}: ${err.message}`);
+        }
+      }
+
+      return new JobResponseDto(jobPosts);
+    } catch (err: any) {
+      this.logger.error(`Teamtailor scrape error for ${companySlug}: ${err.message}`);
+      return new JobResponseDto([]);
+    }
+  }
+
+  private processJob(
+    job: TeamtailorJob,
+    companySlug: string,
+    format?: DescriptionFormat,
+  ): JobPostDto | null {
+    const attrs = job.attributes;
+    const title = attrs?.title;
+    if (!title) return null;
+
+    // Description from body (HTML)
+    let description: string | null = null;
+    if (attrs.body) {
+      if (format === DescriptionFormat.HTML) {
+        description = attrs.body;
+      } else {
+        description = htmlToPlainText(attrs.body);
+      }
+    }
+
+    // Location from city/region/country
+    const location = new LocationDto({
+      city: attrs.city ?? null,
+      state: attrs.region ?? null,
+      country: attrs.country ?? null,
+    });
+
+    // Apply URL
+    const applyUrl = attrs['apply-url'] ?? attrs['external-url'] ?? null;
+
+    // Job URL from links
+    const jobUrl = job.links?.['careersite-url']
+      ?? applyUrl
+      ?? `https://career.teamtailor.com/${companySlug}/jobs/${job.id}`;
+
+    // Date posted
+    const createdAt = attrs['created-at'] ?? null;
+    const datePosted = createdAt
+      ? new Date(createdAt).toISOString().split('T')[0]
+      : null;
+
+    // Department from relationships
+    const departmentId = job.relationships?.department?.data?.id ?? null;
+
+    return new JobPostDto({
+      id: `teamtailor-${job.id}`,
+      title,
+      companyName: companySlug,
+      jobUrl,
+      location,
+      description,
+      datePosted,
+      isRemote: attrs.remote ?? false,
+      emails: extractEmails(description),
+      site: Site.TEAMTAILOR,
+      // ATS-specific fields
+      atsId: job.id,
+      atsType: 'teamtailor',
+      department: departmentId,
+      employmentType: attrs['employment-type'] ?? null,
+      applyUrl,
+    });
+  }
+}

--- a/packages/source-ats-teamtailor/src/teamtailor.service.ts
+++ b/packages/source-ats-teamtailor/src/teamtailor.service.ts
@@ -11,6 +11,7 @@ import {
 import {
   createHttpClient,
   htmlToPlainText,
+  markdownConverter,
   extractEmails,
 } from '@ever-jobs/common';
 import { TEAMTAILOR_API_URL, TEAMTAILOR_HEADERS } from './teamtailor.constants';
@@ -86,6 +87,8 @@ export class TeamtailorService implements IScraper {
     if (attrs.body) {
       if (format === DescriptionFormat.HTML) {
         description = attrs.body;
+      } else if (format === DescriptionFormat.MARKDOWN) {
+        description = markdownConverter(attrs.body) ?? attrs.body;
       } else {
         description = htmlToPlainText(attrs.body);
       }

--- a/packages/source-ats-teamtailor/src/teamtailor.types.ts
+++ b/packages/source-ats-teamtailor/src/teamtailor.types.ts
@@ -1,0 +1,33 @@
+/**
+ * TypeScript interfaces for Teamtailor API responses.
+ */
+
+export interface TeamtailorResponse {
+  data: TeamtailorJob[];
+}
+
+export interface TeamtailorJob {
+  id: string;
+  type: string;
+  attributes: {
+    title: string;
+    body: string;
+    pitch?: string;
+    'employment-type'?: string;
+    'external-url'?: string;
+    'apply-url'?: string;
+    remote?: boolean;
+    'created-at'?: string;
+    'updated-at'?: string;
+    city?: string;
+    region?: string;
+    country?: string;
+  };
+  relationships?: {
+    department?: { data?: { id: string } };
+  };
+  links?: {
+    self?: string;
+    'careersite-url'?: string;
+  };
+}

--- a/packages/source-ats-teamtailor/tsconfig.json
+++ b/packages/source-ats-teamtailor/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../dist/packages/source-ats-teamtailor",
+    "declaration": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/source-himalayas/package.json
+++ b/packages/source-himalayas/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@ever-jobs/source-himalayas",
+  "version": "0.1.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "MIT"
+}

--- a/packages/source-himalayas/src/himalayas.constants.ts
+++ b/packages/source-himalayas/src/himalayas.constants.ts
@@ -1,0 +1,6 @@
+export const HIMALAYAS_API_URL = 'https://himalayas.app/jobs/api';
+export const HIMALAYAS_HEADERS: Record<string, string> = {
+  Accept: 'application/json',
+  'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129 Safari/537.36',
+};
+export const HIMALAYAS_PAGE_SIZE = 20;

--- a/packages/source-himalayas/src/himalayas.module.ts
+++ b/packages/source-himalayas/src/himalayas.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { HimalayasService } from './himalayas.service';
+
+@Module({
+  providers: [HimalayasService],
+  exports: [HimalayasService],
+})
+export class HimalayasModule {}

--- a/packages/source-himalayas/src/himalayas.service.ts
+++ b/packages/source-himalayas/src/himalayas.service.ts
@@ -1,0 +1,142 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  IScraper,
+  ScraperInputDto,
+  JobResponseDto,
+  JobPostDto,
+  LocationDto,
+  CompensationDto,
+  CompensationInterval,
+  Site,
+  DescriptionFormat,
+} from '@ever-jobs/models';
+import {
+  createHttpClient,
+  htmlToPlainText,
+  extractEmails,
+} from '@ever-jobs/common';
+import { HIMALAYAS_API_URL, HIMALAYAS_HEADERS, HIMALAYAS_PAGE_SIZE } from './himalayas.constants';
+import { HimalayasJob, HimalayasApiResponse } from './himalayas.types';
+
+@Injectable()
+export class HimalayasService implements IScraper {
+  private readonly logger = new Logger(HimalayasService.name);
+
+  async scrape(input: ScraperInputDto): Promise<JobResponseDto> {
+    const resultsWanted = input.resultsWanted ?? 15;
+
+    const client = createHttpClient({
+      proxies: input.proxies,
+      caCert: input.caCert,
+      timeout: input.requestTimeout,
+    });
+    client.setHeaders(HIMALAYAS_HEADERS);
+
+    const jobs: JobPostDto[] = [];
+    const seenIds = new Set<string>();
+    let offset = input.offset ?? 0;
+
+    while (jobs.length < resultsWanted) {
+      const limit = Math.min(HIMALAYAS_PAGE_SIZE, resultsWanted - jobs.length);
+
+      this.logger.log(`Fetching Himalayas jobs (offset=${offset}, limit=${limit})`);
+
+      try {
+        const response = await client.get<HimalayasApiResponse>(HIMALAYAS_API_URL, {
+          params: { limit, offset },
+        });
+
+        const rawJobs = response.data?.jobs ?? [];
+        if (rawJobs.length === 0) {
+          this.logger.log('No more Himalayas jobs available');
+          break;
+        }
+
+        this.logger.log(`Himalayas returned ${rawJobs.length} jobs (total available: ${response.data?.totalCount ?? 'unknown'})`);
+
+        for (const raw of rawJobs) {
+          if (jobs.length >= resultsWanted) break;
+
+          const jobId = `himalayas-${raw.guid}`;
+          if (seenIds.has(jobId)) continue;
+          seenIds.add(jobId);
+
+          try {
+            const job = this.mapJob(raw, input.descriptionFormat);
+            if (job) jobs.push(job);
+          } catch (err: any) {
+            this.logger.warn(`Error mapping Himalayas job ${raw.guid}: ${err.message}`);
+          }
+        }
+
+        offset += rawJobs.length;
+
+        // Stop if we got fewer results than requested (last page)
+        if (rawJobs.length < limit) break;
+      } catch (err: any) {
+        this.logger.error(`Himalayas scrape error: ${err.message}`);
+        break;
+      }
+    }
+
+    return new JobResponseDto(jobs);
+  }
+
+  private mapJob(raw: HimalayasJob, descriptionFormat?: DescriptionFormat): JobPostDto | null {
+    if (!raw.title) return null;
+
+    // Process description
+    let description: string | null = raw.description ?? null;
+    if (description) {
+      if (descriptionFormat === DescriptionFormat.PLAIN) {
+        description = htmlToPlainText(description);
+      }
+    }
+
+    // Build compensation
+    let compensation: CompensationDto | null = null;
+    const hasMin = raw.minSalary != null && raw.minSalary !== 0;
+    const hasMax = raw.maxSalary != null && raw.maxSalary !== 0;
+    if (hasMin || hasMax) {
+      compensation = new CompensationDto({
+        interval: CompensationInterval.YEARLY,
+        minAmount: raw.minSalary ?? null,
+        maxAmount: raw.maxSalary ?? null,
+        currency: raw.currency ?? 'USD',
+      });
+    }
+
+    // Build location from first location restriction
+    const location = new LocationDto({
+      country: raw.locationRestrictions?.[0] ?? null,
+    });
+
+    // Parse date from Unix timestamp (seconds)
+    let datePosted: string | null = null;
+    if (raw.pubDate) {
+      try {
+        datePosted = new Date(raw.pubDate * 1000).toISOString().split('T')[0];
+      } catch {
+        datePosted = null;
+      }
+    }
+
+    return new JobPostDto({
+      id: `himalayas-${raw.guid}`,
+      title: raw.title,
+      companyName: raw.companyName ?? null,
+      companyLogo: raw.companyLogo ?? null,
+      jobUrl: raw.applicationLink ?? null,
+      applyUrl: raw.applicationLink ?? null,
+      location,
+      description,
+      compensation,
+      datePosted,
+      isRemote: true,
+      employmentType: raw.employmentType ?? null,
+      jobLevel: raw.seniority?.join(', ') ?? null,
+      emails: extractEmails(description),
+      site: Site.HIMALAYAS,
+    });
+  }
+}

--- a/packages/source-himalayas/src/himalayas.service.ts
+++ b/packages/source-himalayas/src/himalayas.service.ts
@@ -13,6 +13,7 @@ import {
 import {
   createHttpClient,
   htmlToPlainText,
+  markdownConverter,
   extractEmails,
 } from '@ever-jobs/common';
 import { HIMALAYAS_API_URL, HIMALAYAS_HEADERS, HIMALAYAS_PAGE_SIZE } from './himalayas.constants';
@@ -83,13 +84,15 @@ export class HimalayasService implements IScraper {
   }
 
   private mapJob(raw: HimalayasJob, descriptionFormat?: DescriptionFormat): JobPostDto | null {
-    if (!raw.title) return null;
+    if (!raw.title || !raw.applicationLink) return null;
 
-    // Process description
+    // Process description (Himalayas returns HTML)
     let description: string | null = raw.description ?? null;
     if (description) {
       if (descriptionFormat === DescriptionFormat.PLAIN) {
         description = htmlToPlainText(description);
+      } else if (descriptionFormat === DescriptionFormat.MARKDOWN) {
+        description = markdownConverter(description) ?? description;
       }
     }
 
@@ -126,8 +129,8 @@ export class HimalayasService implements IScraper {
       title: raw.title,
       companyName: raw.companyName ?? null,
       companyLogo: raw.companyLogo ?? null,
-      jobUrl: raw.applicationLink ?? null,
-      applyUrl: raw.applicationLink ?? null,
+      jobUrl: raw.applicationLink,
+      applyUrl: raw.applicationLink,
       location,
       description,
       compensation,

--- a/packages/source-himalayas/src/himalayas.types.ts
+++ b/packages/source-himalayas/src/himalayas.types.ts
@@ -1,0 +1,33 @@
+/**
+ * Shape of a single job returned by the Himalayas API.
+ */
+export interface HimalayasJob {
+  title: string;
+  excerpt: string;
+  companyName: string;
+  companyLogo: string;
+  employmentType: string;
+  minSalary: number;
+  maxSalary: number;
+  seniority: string[];
+  currency: string;
+  locationRestrictions: string[];
+  timezoneRestrictions: string[];
+  categories: string[];
+  parentCategories: string[];
+  description: string;
+  pubDate: number;
+  expiryDate: number;
+  applicationLink: string;
+  guid: string;
+}
+
+/**
+ * Top-level response envelope from the Himalayas API.
+ */
+export interface HimalayasApiResponse {
+  jobs: HimalayasJob[];
+  totalCount: number;
+  offset: number;
+  limit: number;
+}

--- a/packages/source-himalayas/src/index.ts
+++ b/packages/source-himalayas/src/index.ts
@@ -1,0 +1,2 @@
+export { HimalayasModule } from './himalayas.module';
+export { HimalayasService } from './himalayas.service';

--- a/packages/source-himalayas/tsconfig.json
+++ b/packages/source-himalayas/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../dist/packages/source-himalayas",
+    "declaration": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/source-jobicy/package.json
+++ b/packages/source-jobicy/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@ever-jobs/source-jobicy",
+  "version": "0.1.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "MIT"
+}

--- a/packages/source-jobicy/src/index.ts
+++ b/packages/source-jobicy/src/index.ts
@@ -1,0 +1,2 @@
+export { JobicyModule } from './jobicy.module';
+export { JobicyService } from './jobicy.service';

--- a/packages/source-jobicy/src/jobicy.constants.ts
+++ b/packages/source-jobicy/src/jobicy.constants.ts
@@ -1,0 +1,5 @@
+export const JOBICY_API_URL = 'https://jobicy.com/api/v2/remote-jobs';
+export const JOBICY_HEADERS: Record<string, string> = {
+  Accept: 'application/json',
+  'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129 Safari/537.36',
+};

--- a/packages/source-jobicy/src/jobicy.module.ts
+++ b/packages/source-jobicy/src/jobicy.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { JobicyService } from './jobicy.service';
+
+@Module({
+  providers: [JobicyService],
+  exports: [JobicyService],
+})
+export class JobicyModule {}

--- a/packages/source-jobicy/src/jobicy.service.ts
+++ b/packages/source-jobicy/src/jobicy.service.ts
@@ -1,0 +1,132 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  IScraper,
+  ScraperInputDto,
+  JobResponseDto,
+  JobPostDto,
+  LocationDto,
+  CompensationDto,
+  CompensationInterval,
+  Site,
+  DescriptionFormat,
+} from '@ever-jobs/models';
+import {
+  createHttpClient,
+  htmlToPlainText,
+  extractEmails,
+} from '@ever-jobs/common';
+import { JOBICY_API_URL, JOBICY_HEADERS } from './jobicy.constants';
+import { JobicyJob, JobicyApiResponse } from './jobicy.types';
+
+@Injectable()
+export class JobicyService implements IScraper {
+  private readonly logger = new Logger(JobicyService.name);
+
+  async scrape(input: ScraperInputDto): Promise<JobResponseDto> {
+    const count = Math.min(input.resultsWanted ?? 50, 50);
+
+    const client = createHttpClient({
+      proxies: input.proxies,
+      caCert: input.caCert,
+      timeout: input.requestTimeout,
+    });
+    client.setHeaders(JOBICY_HEADERS);
+
+    const params: Record<string, string | number> = {
+      count,
+    };
+
+    if (input.location) {
+      params.geo = input.location;
+    }
+    if (input.searchTerm) {
+      params.tag = input.searchTerm;
+    }
+
+    this.logger.log(`Fetching Jobicy remote jobs (count=${count})`);
+
+    try {
+      const response = await client.get<JobicyApiResponse>(JOBICY_API_URL, {
+        params,
+      });
+
+      const rawJobs = response.data?.jobs ?? [];
+      this.logger.log(`Jobicy returned ${rawJobs.length} jobs`);
+
+      const jobs: JobPostDto[] = [];
+
+      for (const raw of rawJobs) {
+        try {
+          const job = this.mapJob(raw, input.descriptionFormat);
+          if (job) jobs.push(job);
+        } catch (err: any) {
+          this.logger.warn(`Error mapping Jobicy job ${raw.id}: ${err.message}`);
+        }
+      }
+
+      return new JobResponseDto(jobs);
+    } catch (err: any) {
+      this.logger.error(`Jobicy scrape error: ${err.message}`);
+      return new JobResponseDto([]);
+    }
+  }
+
+  private mapJob(raw: JobicyJob, descriptionFormat?: DescriptionFormat): JobPostDto | null {
+    if (!raw.jobTitle || !raw.url) return null;
+
+    // Process description
+    let description: string | null = raw.jobDescription ?? null;
+    if (description) {
+      if (descriptionFormat === DescriptionFormat.PLAIN) {
+        description = htmlToPlainText(description);
+      }
+      // HTML is kept as-is for HTML format; for MARKDOWN we also convert
+      // (Jobicy returns HTML, so plain-text strip is a safe default for non-HTML)
+    }
+
+    // Build compensation
+    let compensation: CompensationDto | null = null;
+    const hasMin = raw.annualSalaryMin != null && raw.annualSalaryMin !== 0;
+    const hasMax = raw.annualSalaryMax != null && raw.annualSalaryMax !== 0;
+    if (hasMin || hasMax) {
+      compensation = new CompensationDto({
+        interval: CompensationInterval.YEARLY,
+        minAmount: raw.annualSalaryMin ?? null,
+        maxAmount: raw.annualSalaryMax ?? null,
+        currency: raw.salaryCurrency ?? 'USD',
+      });
+    }
+
+    // Build location
+    const location = new LocationDto({
+      city: raw.jobGeo ?? null,
+    });
+
+    // Parse date
+    let datePosted: string | null = null;
+    if (raw.pubDate) {
+      try {
+        datePosted = new Date(raw.pubDate).toISOString().split('T')[0];
+      } catch {
+        datePosted = raw.pubDate;
+      }
+    }
+
+    return new JobPostDto({
+      id: `jobicy-${raw.id}`,
+      title: raw.jobTitle,
+      companyName: raw.companyName ?? null,
+      companyLogo: raw.companyLogo ?? null,
+      jobUrl: raw.url,
+      location,
+      description,
+      compensation,
+      datePosted,
+      isRemote: true,
+      jobLevel: raw.jobLevel ?? null,
+      companyIndustry: raw.jobIndustry?.join(', ') ?? null,
+      emails: extractEmails(description),
+      site: Site.JOBICY,
+    });
+  }
+}

--- a/packages/source-jobicy/src/jobicy.service.ts
+++ b/packages/source-jobicy/src/jobicy.service.ts
@@ -13,6 +13,7 @@ import {
 import {
   createHttpClient,
   htmlToPlainText,
+  markdownConverter,
   extractEmails,
 } from '@ever-jobs/common';
 import { JOBICY_API_URL, JOBICY_HEADERS } from './jobicy.constants';
@@ -74,14 +75,14 @@ export class JobicyService implements IScraper {
   private mapJob(raw: JobicyJob, descriptionFormat?: DescriptionFormat): JobPostDto | null {
     if (!raw.jobTitle || !raw.url) return null;
 
-    // Process description
+    // Process description (Jobicy returns HTML)
     let description: string | null = raw.jobDescription ?? null;
     if (description) {
       if (descriptionFormat === DescriptionFormat.PLAIN) {
         description = htmlToPlainText(description);
+      } else if (descriptionFormat === DescriptionFormat.MARKDOWN) {
+        description = markdownConverter(description) ?? description;
       }
-      // HTML is kept as-is for HTML format; for MARKDOWN we also convert
-      // (Jobicy returns HTML, so plain-text strip is a safe default for non-HTML)
     }
 
     // Build compensation

--- a/packages/source-jobicy/src/jobicy.types.ts
+++ b/packages/source-jobicy/src/jobicy.types.ts
@@ -1,0 +1,28 @@
+/**
+ * Shape of a single job returned by the Jobicy v2 API.
+ */
+export interface JobicyJob {
+  id: number;
+  url: string;
+  jobSlug: string;
+  jobTitle: string;
+  companyName: string;
+  companyLogo: string;
+  jobIndustry: string[];
+  jobType: string[];
+  jobGeo: string;
+  jobLevel: string;
+  jobExcerpt: string;
+  jobDescription: string;
+  pubDate: string;
+  annualSalaryMin?: number | null;
+  annualSalaryMax?: number | null;
+  salaryCurrency?: string | null;
+}
+
+/**
+ * Top-level response envelope from the Jobicy API.
+ */
+export interface JobicyApiResponse {
+  jobs: JobicyJob[];
+}

--- a/packages/source-jobicy/tsconfig.json
+++ b/packages/source-jobicy/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../dist/packages/source-jobicy",
+    "declaration": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/source-remoteok/package.json
+++ b/packages/source-remoteok/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@ever-jobs/source-remoteok",
+  "version": "0.1.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "MIT"
+}

--- a/packages/source-remoteok/src/index.ts
+++ b/packages/source-remoteok/src/index.ts
@@ -1,0 +1,2 @@
+export { RemoteOkModule } from './remoteok.module';
+export { RemoteOkService } from './remoteok.service';

--- a/packages/source-remoteok/src/remoteok.constants.ts
+++ b/packages/source-remoteok/src/remoteok.constants.ts
@@ -1,0 +1,6 @@
+export const REMOTEOK_API_URL = 'https://remoteok.com/api';
+export const REMOTEOK_HEADERS: Record<string, string> = {
+  Accept: 'application/json',
+  'User-Agent':
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129 Safari/537.36',
+};

--- a/packages/source-remoteok/src/remoteok.module.ts
+++ b/packages/source-remoteok/src/remoteok.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { RemoteOkService } from './remoteok.service';
+
+@Module({
+  providers: [RemoteOkService],
+  exports: [RemoteOkService],
+})
+export class RemoteOkModule {}

--- a/packages/source-remoteok/src/remoteok.service.ts
+++ b/packages/source-remoteok/src/remoteok.service.ts
@@ -1,0 +1,157 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  IScraper,
+  ScraperInputDto,
+  JobResponseDto,
+  JobPostDto,
+  LocationDto,
+  CompensationDto,
+  Site,
+  DescriptionFormat,
+  CompensationInterval,
+} from '@ever-jobs/models';
+import { createHttpClient, htmlToPlainText, extractEmails } from '@ever-jobs/common';
+import { REMOTEOK_API_URL, REMOTEOK_HEADERS } from './remoteok.constants';
+import { RemoteOkJob } from './remoteok.types';
+
+@Injectable()
+export class RemoteOkService implements IScraper {
+  private readonly logger = new Logger(RemoteOkService.name);
+
+  async scrape(input: ScraperInputDto): Promise<JobResponseDto> {
+    const limit = input.resultsWanted ?? 100;
+
+    this.logger.log(
+      `RemoteOK scrape: search="${input.searchTerm ?? ''}" limit=${limit}`,
+    );
+
+    try {
+      const http = createHttpClient({
+        proxies: input.proxies,
+        caCert: input.caCert,
+        timeout: input.requestTimeout,
+      });
+
+      const response = await http.get<unknown[]>(REMOTEOK_API_URL, {
+        headers: REMOTEOK_HEADERS,
+      });
+
+      const raw = response.data;
+
+      if (!Array.isArray(raw) || raw.length < 2) {
+        this.logger.warn('RemoteOK returned empty or invalid response');
+        return new JobResponseDto([]);
+      }
+
+      // First element is metadata (contains "legal" key), skip it
+      const jobEntries = raw.slice(1) as RemoteOkJob[];
+
+      // Filter by searchTerm if provided
+      let filtered = jobEntries;
+      if (input.searchTerm) {
+        const term = input.searchTerm.toLowerCase();
+        filtered = jobEntries.filter((job) => {
+          const positionMatch = job.position?.toLowerCase().includes(term);
+          const tagsMatch = job.tags?.some((tag) =>
+            tag.toLowerCase().includes(term),
+          );
+          return positionMatch || tagsMatch;
+        });
+      }
+
+      // Limit results
+      const limited = filtered.slice(0, limit);
+
+      this.logger.log(
+        `RemoteOK: ${jobEntries.length} total, ${filtered.length} after filter, returning ${limited.length}`,
+      );
+
+      const jobs: JobPostDto[] = [];
+
+      for (const entry of limited) {
+        try {
+          const job = this.mapJob(entry, input.descriptionFormat);
+          if (job) {
+            jobs.push(job);
+          }
+        } catch (err: any) {
+          this.logger.warn(
+            `Error mapping RemoteOK job ${entry.id}: ${err.message}`,
+          );
+        }
+      }
+
+      return new JobResponseDto(jobs);
+    } catch (err: any) {
+      this.logger.error(`RemoteOK scrape error: ${err.message}`);
+      return new JobResponseDto([]);
+    }
+  }
+
+  /**
+   * Map a raw RemoteOK API job object to a JobPostDto.
+   */
+  private mapJob(
+    entry: RemoteOkJob,
+    descriptionFormat?: DescriptionFormat,
+  ): JobPostDto | null {
+    if (!entry.position || !entry.url) {
+      return null;
+    }
+
+    // Process description
+    let description: string | null = entry.description ?? null;
+    if (description) {
+      if (
+        descriptionFormat === DescriptionFormat.PLAIN ||
+        descriptionFormat === undefined
+      ) {
+        description = htmlToPlainText(description);
+      }
+      // For HTML format, keep as-is; for MARKDOWN, also use plain text
+      // since we don't have a full markdown converter for arbitrary HTML here
+      if (descriptionFormat === DescriptionFormat.MARKDOWN) {
+        description = htmlToPlainText(description);
+      }
+    }
+
+    // Build compensation if salary data is present
+    let compensation: CompensationDto | null = null;
+    if (entry.salary_min && entry.salary_max && entry.salary_min > 0 && entry.salary_max > 0) {
+      compensation = new CompensationDto({
+        interval: CompensationInterval.YEARLY,
+        minAmount: entry.salary_min,
+        maxAmount: entry.salary_max,
+        currency: 'USD',
+      });
+    }
+
+    // Build location
+    const location = new LocationDto({
+      city: entry.location || null,
+    });
+
+    // Parse date
+    const datePosted = entry.date
+      ? entry.date.split('T')[0]
+      : null;
+
+    return new JobPostDto({
+      id: `remoteok-${entry.id}`,
+      title: entry.position,
+      companyName: entry.company || null,
+      companyLogo: entry.company_logo || null,
+      jobUrl: entry.url,
+      jobUrlDirect: entry.apply_url || null,
+      applyUrl: entry.apply_url || null,
+      location,
+      description,
+      compensation,
+      datePosted,
+      isRemote: true,
+      emails: extractEmails(description),
+      site: Site.REMOTEOK,
+      skills: entry.tags?.length > 0 ? entry.tags : null,
+    });
+  }
+}

--- a/packages/source-remoteok/src/remoteok.service.ts
+++ b/packages/source-remoteok/src/remoteok.service.ts
@@ -10,7 +10,7 @@ import {
   DescriptionFormat,
   CompensationInterval,
 } from '@ever-jobs/models';
-import { createHttpClient, htmlToPlainText, extractEmails } from '@ever-jobs/common';
+import { createHttpClient, htmlToPlainText, markdownConverter, extractEmails } from '@ever-jobs/common';
 import { REMOTEOK_API_URL, REMOTEOK_HEADERS } from './remoteok.constants';
 import { RemoteOkJob } from './remoteok.types';
 
@@ -99,19 +99,13 @@ export class RemoteOkService implements IScraper {
       return null;
     }
 
-    // Process description
+    // Process description (RemoteOK returns HTML)
     let description: string | null = entry.description ?? null;
     if (description) {
-      if (
-        descriptionFormat === DescriptionFormat.PLAIN ||
-        descriptionFormat === undefined
-      ) {
+      if (descriptionFormat === DescriptionFormat.PLAIN) {
         description = htmlToPlainText(description);
-      }
-      // For HTML format, keep as-is; for MARKDOWN, also use plain text
-      // since we don't have a full markdown converter for arbitrary HTML here
-      if (descriptionFormat === DescriptionFormat.MARKDOWN) {
-        description = htmlToPlainText(description);
+      } else if (descriptionFormat === DescriptionFormat.MARKDOWN) {
+        description = markdownConverter(description) ?? description;
       }
     }
 

--- a/packages/source-remoteok/src/remoteok.types.ts
+++ b/packages/source-remoteok/src/remoteok.types.ts
@@ -1,0 +1,21 @@
+/**
+ * Shape of a single job object returned by the RemoteOK API.
+ * The API returns a JSON array where the first element is a metadata
+ * object (with a "legal" key) and the remaining elements are job objects.
+ */
+export interface RemoteOkJob {
+  slug: string;
+  id: string;
+  epoch: number;
+  date: string;
+  company: string;
+  company_logo: string;
+  position: string;
+  tags: string[];
+  description: string;
+  location: string;
+  apply_url: string;
+  salary_min: number;
+  salary_max: number;
+  url: string;
+}

--- a/packages/source-remoteok/tsconfig.json
+++ b/packages/source-remoteok/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../dist/packages/source-remoteok",
+    "declaration": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/source-remotive/package.json
+++ b/packages/source-remotive/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@ever-jobs/source-remotive",
+  "version": "0.1.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "MIT"
+}

--- a/packages/source-remotive/src/index.ts
+++ b/packages/source-remotive/src/index.ts
@@ -1,0 +1,2 @@
+export { RemotiveModule } from './remotive.module';
+export { RemotiveService } from './remotive.service';

--- a/packages/source-remotive/src/remotive.constants.ts
+++ b/packages/source-remotive/src/remotive.constants.ts
@@ -1,0 +1,6 @@
+export const REMOTIVE_API_URL = 'https://remotive.com/api/remote-jobs';
+export const REMOTIVE_HEADERS: Record<string, string> = {
+  Accept: 'application/json',
+  'User-Agent':
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129 Safari/537.36',
+};

--- a/packages/source-remotive/src/remotive.module.ts
+++ b/packages/source-remotive/src/remotive.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { RemotiveService } from './remotive.service';
+
+@Module({
+  providers: [RemotiveService],
+  exports: [RemotiveService],
+})
+export class RemotiveModule {}

--- a/packages/source-remotive/src/remotive.service.ts
+++ b/packages/source-remotive/src/remotive.service.ts
@@ -1,0 +1,194 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  IScraper,
+  ScraperInputDto,
+  JobResponseDto,
+  JobPostDto,
+  LocationDto,
+  CompensationDto,
+  Site,
+  DescriptionFormat,
+  CompensationInterval,
+  JobType,
+} from '@ever-jobs/models';
+import { createHttpClient, htmlToPlainText, extractEmails } from '@ever-jobs/common';
+import { REMOTIVE_API_URL, REMOTIVE_HEADERS } from './remotive.constants';
+import { RemotiveApiResponse, RemotiveJob } from './remotive.types';
+
+/** Map Remotive job_type strings to our JobType enum. */
+const JOB_TYPE_MAP: Record<string, JobType> = {
+  full_time: JobType.FULL_TIME,
+  part_time: JobType.PART_TIME,
+  contract: JobType.CONTRACT,
+  freelance: JobType.CONTRACT,
+  internship: JobType.INTERNSHIP,
+  temporary: JobType.TEMPORARY,
+  volunteer: JobType.VOLUNTEER,
+  other: JobType.OTHER,
+};
+
+/** Regex to parse salary strings like "$60,000 - $80,000". */
+const SALARY_REGEX = /\$?([\d,]+)\s*[-\u2013]\s*\$?([\d,]+)/;
+
+@Injectable()
+export class RemotiveService implements IScraper {
+  private readonly logger = new Logger(RemotiveService.name);
+
+  async scrape(input: ScraperInputDto): Promise<JobResponseDto> {
+    const limit = input.resultsWanted ?? 100;
+
+    this.logger.log(
+      `Remotive scrape: search="${input.searchTerm ?? ''}" limit=${limit}`,
+    );
+
+    try {
+      const http = createHttpClient({
+        proxies: input.proxies,
+        caCert: input.caCert,
+        timeout: input.requestTimeout,
+      });
+
+      // Build query params
+      const params: Record<string, string | number> = {
+        limit,
+      };
+      if (input.searchTerm) {
+        params.search = input.searchTerm;
+      }
+
+      const response = await http.get<RemotiveApiResponse>(REMOTIVE_API_URL, {
+        headers: REMOTIVE_HEADERS,
+        params,
+      });
+
+      const data = response.data;
+      if (!data?.jobs || !Array.isArray(data.jobs)) {
+        this.logger.warn('Remotive returned empty or invalid response');
+        return new JobResponseDto([]);
+      }
+
+      this.logger.log(`Remotive returned ${data.jobs.length} jobs`);
+
+      const jobs: JobPostDto[] = [];
+
+      for (const entry of data.jobs) {
+        try {
+          const job = this.mapJob(entry, input.descriptionFormat);
+          if (job) {
+            jobs.push(job);
+          }
+        } catch (err: any) {
+          this.logger.warn(
+            `Error mapping Remotive job ${entry.id}: ${err.message}`,
+          );
+        }
+      }
+
+      return new JobResponseDto(jobs);
+    } catch (err: any) {
+      this.logger.error(`Remotive scrape error: ${err.message}`);
+      return new JobResponseDto([]);
+    }
+  }
+
+  /**
+   * Map a raw Remotive API job object to a JobPostDto.
+   */
+  private mapJob(
+    entry: RemotiveJob,
+    descriptionFormat?: DescriptionFormat,
+  ): JobPostDto | null {
+    if (!entry.title || !entry.url) {
+      return null;
+    }
+
+    // Process description
+    let description: string | null = entry.description ?? null;
+    if (description) {
+      if (
+        descriptionFormat === DescriptionFormat.PLAIN ||
+        descriptionFormat === undefined
+      ) {
+        description = htmlToPlainText(description);
+      }
+      if (descriptionFormat === DescriptionFormat.MARKDOWN) {
+        description = htmlToPlainText(description);
+      }
+    }
+
+    // Parse salary
+    const compensation = this.parseSalary(entry.salary);
+
+    // Build location
+    const location = new LocationDto({
+      city: entry.candidate_required_location || null,
+    });
+
+    // Map job type
+    const jobType = this.mapJobType(entry.job_type);
+
+    // Parse date (extract date part from ISO 8601)
+    const datePosted = entry.publication_date
+      ? entry.publication_date.split('T')[0]
+      : null;
+
+    // Prefer company_logo_url, fall back to company_logo
+    const companyLogo = entry.company_logo_url || entry.company_logo || null;
+
+    return new JobPostDto({
+      id: `remotive-${entry.id}`,
+      title: entry.title,
+      companyName: entry.company_name || null,
+      companyLogo,
+      jobUrl: entry.url,
+      location,
+      description,
+      compensation,
+      datePosted,
+      jobType: jobType ? [jobType] : null,
+      isRemote: true,
+      emails: extractEmails(description),
+      site: Site.REMOTIVE,
+      skills: entry.tags?.length > 0 ? entry.tags : null,
+    });
+  }
+
+  /**
+   * Parse a salary string like "$60,000 - $80,000" into a CompensationDto.
+   */
+  private parseSalary(salary: string | null | undefined): CompensationDto | null {
+    if (!salary) {
+      return null;
+    }
+
+    const match = salary.match(SALARY_REGEX);
+    if (!match) {
+      return null;
+    }
+
+    const minAmount = parseInt(match[1].replace(/,/g, ''), 10);
+    const maxAmount = parseInt(match[2].replace(/,/g, ''), 10);
+
+    if (isNaN(minAmount) || isNaN(maxAmount) || minAmount <= 0 || maxAmount <= 0) {
+      return null;
+    }
+
+    return new CompensationDto({
+      interval: CompensationInterval.YEARLY,
+      minAmount,
+      maxAmount,
+      currency: 'USD',
+    });
+  }
+
+  /**
+   * Map a Remotive job_type string to our JobType enum.
+   */
+  private mapJobType(jobType: string | null | undefined): JobType | null {
+    if (!jobType) {
+      return null;
+    }
+    const normalized = jobType.toLowerCase().trim();
+    return JOB_TYPE_MAP[normalized] ?? null;
+  }
+}

--- a/packages/source-remotive/src/remotive.service.ts
+++ b/packages/source-remotive/src/remotive.service.ts
@@ -11,7 +11,7 @@ import {
   CompensationInterval,
   JobType,
 } from '@ever-jobs/models';
-import { createHttpClient, htmlToPlainText, extractEmails } from '@ever-jobs/common';
+import { createHttpClient, htmlToPlainText, markdownConverter, extractEmails } from '@ever-jobs/common';
 import { REMOTIVE_API_URL, REMOTIVE_HEADERS } from './remotive.constants';
 import { RemotiveApiResponse, RemotiveJob } from './remotive.types';
 
@@ -27,8 +27,12 @@ const JOB_TYPE_MAP: Record<string, JobType> = {
   other: JobType.OTHER,
 };
 
-/** Regex to parse salary strings like "$60,000 - $80,000". */
-const SALARY_REGEX = /\$?([\d,]+)\s*[-\u2013]\s*\$?([\d,]+)/;
+/**
+ * Regex to parse salary strings like "$60,000 - $80,000".
+ * Uses non-overlapping number pattern (\d{1,3}(?:,\d{3})*|\d+) instead of
+ * [\d,]+ to prevent super-linear backtracking (ReDoS).
+ */
+const SALARY_REGEX = /\$?(\d{1,3}(?:,\d{3})*|\d+)\s*[-\u2013]\s*\$?(\d{1,3}(?:,\d{3})*|\d+)/;
 
 @Injectable()
 export class RemotiveService implements IScraper {
@@ -102,17 +106,13 @@ export class RemotiveService implements IScraper {
       return null;
     }
 
-    // Process description
+    // Process description (Remotive returns HTML)
     let description: string | null = entry.description ?? null;
     if (description) {
-      if (
-        descriptionFormat === DescriptionFormat.PLAIN ||
-        descriptionFormat === undefined
-      ) {
+      if (descriptionFormat === DescriptionFormat.PLAIN) {
         description = htmlToPlainText(description);
-      }
-      if (descriptionFormat === DescriptionFormat.MARKDOWN) {
-        description = htmlToPlainText(description);
+      } else if (descriptionFormat === DescriptionFormat.MARKDOWN) {
+        description = markdownConverter(description) ?? description;
       }
     }
 

--- a/packages/source-remotive/src/remotive.types.ts
+++ b/packages/source-remotive/src/remotive.types.ts
@@ -1,0 +1,25 @@
+/**
+ * Shape of the Remotive API response.
+ */
+export interface RemotiveApiResponse {
+  jobs: RemotiveJob[];
+}
+
+/**
+ * Shape of a single job object returned by the Remotive API.
+ */
+export interface RemotiveJob {
+  id: number;
+  url: string;
+  title: string;
+  company_name: string;
+  company_logo: string;
+  company_logo_url: string;
+  category: string;
+  tags: string[];
+  job_type: string;
+  publication_date: string;
+  candidate_required_location: string;
+  salary: string;
+  description: string;
+}

--- a/packages/source-remotive/tsconfig.json
+++ b/packages/source-remotive/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../dist/packages/source-remotive",
+    "declaration": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/source-weworkremotely/package.json
+++ b/packages/source-weworkremotely/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@ever-jobs/source-weworkremotely",
+  "version": "0.1.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "MIT"
+}

--- a/packages/source-weworkremotely/src/index.ts
+++ b/packages/source-weworkremotely/src/index.ts
@@ -1,0 +1,2 @@
+export { WeWorkRemotelyModule } from './weworkremotely.module';
+export { WeWorkRemotelyService } from './weworkremotely.service';

--- a/packages/source-weworkremotely/src/weworkremotely.constants.ts
+++ b/packages/source-weworkremotely/src/weworkremotely.constants.ts
@@ -1,0 +1,5 @@
+export const WWR_RSS_URL = 'https://weworkremotely.com/remote-jobs.rss';
+export const WWR_HEADERS: Record<string, string> = {
+  Accept: 'application/rss+xml, application/xml, text/xml',
+  'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129 Safari/537.36',
+};

--- a/packages/source-weworkremotely/src/weworkremotely.module.ts
+++ b/packages/source-weworkremotely/src/weworkremotely.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { WeWorkRemotelyService } from './weworkremotely.service';
+
+@Module({
+  providers: [WeWorkRemotelyService],
+  exports: [WeWorkRemotelyService],
+})
+export class WeWorkRemotelyModule {}

--- a/packages/source-weworkremotely/src/weworkremotely.service.ts
+++ b/packages/source-weworkremotely/src/weworkremotely.service.ts
@@ -14,6 +14,7 @@ import {
 import {
   createHttpClient,
   htmlToPlainText,
+  markdownConverter,
   extractEmails,
 } from '@ever-jobs/common';
 import { WWR_RSS_URL, WWR_HEADERS } from './weworkremotely.constants';
@@ -162,10 +163,14 @@ export class WeWorkRemotelyService implements IScraper {
       jobTitle = item.title.substring(separatorIndex + 2).trim();
     }
 
-    // Process description (HTML from RSS)
+    // Process description (WeWorkRemotely RSS returns HTML)
     let description: string | null = item.description ?? null;
-    if (description && descriptionFormat === DescriptionFormat.PLAIN) {
-      description = htmlToPlainText(description);
+    if (description) {
+      if (descriptionFormat === DescriptionFormat.PLAIN) {
+        description = htmlToPlainText(description);
+      } else if (descriptionFormat === DescriptionFormat.MARKDOWN) {
+        description = markdownConverter(description) ?? description;
+      }
     }
 
     // Build location

--- a/packages/source-weworkremotely/src/weworkremotely.service.ts
+++ b/packages/source-weworkremotely/src/weworkremotely.service.ts
@@ -1,0 +1,231 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  IScraper,
+  ScraperInputDto,
+  JobResponseDto,
+  JobPostDto,
+  LocationDto,
+  CompensationDto,
+  Site,
+  DescriptionFormat,
+  JobType,
+  getJobTypeFromString,
+} from '@ever-jobs/models';
+import {
+  createHttpClient,
+  htmlToPlainText,
+  extractEmails,
+} from '@ever-jobs/common';
+import { WWR_RSS_URL, WWR_HEADERS } from './weworkremotely.constants';
+import { WwrRssItem } from './weworkremotely.types';
+
+@Injectable()
+export class WeWorkRemotelyService implements IScraper {
+  private readonly logger = new Logger(WeWorkRemotelyService.name);
+
+  async scrape(input: ScraperInputDto): Promise<JobResponseDto> {
+    const resultsWanted = input.resultsWanted ?? 25;
+
+    const client = createHttpClient({
+      proxies: input.proxies,
+      caCert: input.caCert,
+      timeout: input.requestTimeout,
+    });
+    client.setHeaders(WWR_HEADERS);
+
+    this.logger.log(
+      `Fetching We Work Remotely RSS feed (resultsWanted=${resultsWanted})`,
+    );
+
+    try {
+      const response = await client.get<string>(WWR_RSS_URL);
+      const xml = response.data;
+
+      if (!xml || typeof xml !== 'string') {
+        this.logger.warn('Empty or invalid RSS response from We Work Remotely');
+        return new JobResponseDto([]);
+      }
+
+      const items = this.parseRssItems(xml);
+      this.logger.log(`Parsed ${items.length} items from WWR RSS feed`);
+
+      const jobs: JobPostDto[] = [];
+
+      for (const item of items) {
+        if (jobs.length >= resultsWanted) break;
+
+        try {
+          // Filter by search term if provided
+          if (input.searchTerm && !this.matchesSearch(item, input.searchTerm)) {
+            continue;
+          }
+
+          const job = this.mapJob(item, input.descriptionFormat);
+          if (job) jobs.push(job);
+        } catch (err: any) {
+          this.logger.warn(
+            `Error mapping WWR job ${item.link}: ${err.message}`,
+          );
+        }
+      }
+
+      this.logger.log(`We Work Remotely returned ${jobs.length} jobs`);
+      return new JobResponseDto(jobs);
+    } catch (err: any) {
+      this.logger.error(`We Work Remotely scrape error: ${err.message}`);
+      return new JobResponseDto([]);
+    }
+  }
+
+  /**
+   * Parse RSS XML into an array of WwrRssItem using regex (no XML library).
+   */
+  private parseRssItems(xml: string): WwrRssItem[] {
+    const items: WwrRssItem[] = [];
+
+    // Split by <item> tags to get individual entries
+    const itemBlocks = xml.split(/<item>/i).slice(1);
+
+    for (const block of itemBlocks) {
+      // Trim at </item> to avoid leaking into the next item
+      const itemContent = block.split(/<\/item>/i)[0] ?? block;
+
+      items.push({
+        title: this.extractTag(itemContent, 'title'),
+        link: this.extractTag(itemContent, 'link'),
+        guid: this.extractTag(itemContent, 'guid'),
+        description: this.extractTag(itemContent, 'description'),
+        pubDate: this.extractTag(itemContent, 'pubDate'),
+        region: this.extractTag(itemContent, 'region'),
+        country: this.extractTag(itemContent, 'country'),
+        state: this.extractTag(itemContent, 'state'),
+        skills: this.extractTag(itemContent, 'skills'),
+        category: this.extractTag(itemContent, 'category'),
+        type: this.extractTag(itemContent, 'type'),
+      });
+    }
+
+    return items;
+  }
+
+  /**
+   * Extract the text content of an XML tag using regex.
+   * Handles both CDATA-wrapped and plain content.
+   */
+  private extractTag(xml: string, tagName: string): string | null {
+    // Try CDATA first: <tag><![CDATA[content]]></tag>
+    const cdataRegex = new RegExp(
+      `<${tagName}[^>]*>\\s*<!\\[CDATA\\[([\\s\\S]*?)\\]\\]>\\s*<\\/${tagName}>`,
+      'i',
+    );
+    const cdataMatch = cdataRegex.exec(xml);
+    if (cdataMatch) return cdataMatch[1].trim();
+
+    // Try plain content: <tag>content</tag>
+    const plainRegex = new RegExp(
+      `<${tagName}[^>]*>([\\s\\S]*?)<\\/${tagName}>`,
+      'i',
+    );
+    const plainMatch = plainRegex.exec(xml);
+    if (plainMatch) return plainMatch[1].trim();
+
+    return null;
+  }
+
+  /**
+   * Check whether an RSS item matches the given search term.
+   */
+  private matchesSearch(item: WwrRssItem, searchTerm: string): boolean {
+    const term = searchTerm.toLowerCase();
+    const title = (item.title ?? '').toLowerCase();
+    const skills = (item.skills ?? '').toLowerCase();
+
+    return title.includes(term) || skills.includes(term);
+  }
+
+  /**
+   * Map a parsed RSS item to a JobPostDto.
+   */
+  private mapJob(
+    item: WwrRssItem,
+    descriptionFormat?: DescriptionFormat,
+  ): JobPostDto | null {
+    if (!item.title || !item.link) return null;
+
+    // Parse title format "Company: Job Title"
+    let companyName: string | null = null;
+    let jobTitle = item.title;
+
+    const separatorIndex = item.title.indexOf(': ');
+    if (separatorIndex > 0) {
+      companyName = item.title.substring(0, separatorIndex).trim();
+      jobTitle = item.title.substring(separatorIndex + 2).trim();
+    }
+
+    // Process description (HTML from RSS)
+    let description: string | null = item.description ?? null;
+    if (description && descriptionFormat === DescriptionFormat.PLAIN) {
+      description = htmlToPlainText(description);
+    }
+
+    // Build location
+    const location = new LocationDto({
+      city: item.region ?? null,
+      country: item.country ?? null,
+      state: item.state ?? null,
+    });
+
+    // Parse date from RFC 2822 format
+    let datePosted: string | null = null;
+    if (item.pubDate) {
+      try {
+        datePosted = new Date(item.pubDate).toISOString().split('T')[0];
+      } catch {
+        datePosted = null;
+      }
+    }
+
+    // Generate ID from the last path segment of the URL
+    const jobId = this.extractIdFromUrl(item.guid ?? item.link);
+
+    return new JobPostDto({
+      id: `wwr-${jobId}`,
+      title: jobTitle,
+      companyName,
+      jobUrl: item.link,
+      location,
+      description,
+      compensation: null,
+      datePosted,
+      jobType: item.type ? [getJobTypeFromString(item.type)].filter((t): t is JobType => t !== null) : null,
+      isRemote: true,
+      emails: extractEmails(description),
+      site: Site.WEWORKREMOTELY,
+    });
+  }
+
+  /**
+   * Extract a short ID from a URL by using the last path segment.
+   */
+  private extractIdFromUrl(url: string): string {
+    try {
+      const parsed = new URL(url);
+      const segments = parsed.pathname.split('/').filter(Boolean);
+      return segments[segments.length - 1] ?? this.hashString(url);
+    } catch {
+      return this.hashString(url);
+    }
+  }
+
+  /**
+   * Simple string hash for fallback IDs.
+   */
+  private hashString(str: string): string {
+    let hash = 0;
+    for (let i = 0; i < str.length; i++) {
+      const char = str.charCodeAt(i);
+      hash = ((hash << 5) - hash + char) | 0;
+    }
+    return Math.abs(hash).toString(36);
+  }
+}

--- a/packages/source-weworkremotely/src/weworkremotely.types.ts
+++ b/packages/source-weworkremotely/src/weworkremotely.types.ts
@@ -1,0 +1,16 @@
+/**
+ * Shape of a parsed RSS item from We Work Remotely.
+ */
+export interface WwrRssItem {
+  title: string | null;
+  link: string | null;
+  guid: string | null;
+  description: string | null;
+  pubDate: string | null;
+  region: string | null;
+  country: string | null;
+  state: string | null;
+  skills: string | null;
+  category: string | null;
+  type: string | null;
+}

--- a/packages/source-weworkremotely/tsconfig.json
+++ b/packages/source-weworkremotely/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../dist/packages/source-weworkremotely",
+    "declaration": true
+  },
+  "include": ["src/**/*"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -46,7 +46,15 @@
       "@ever-jobs/source-company-nvidia": ["packages/source-company-nvidia/src/index.ts"],
       "@ever-jobs/source-company-tiktok": ["packages/source-company-tiktok/src/index.ts"],
       "@ever-jobs/source-company-uber": ["packages/source-company-uber/src/index.ts"],
-      "@ever-jobs/source-company-cursor": ["packages/source-company-cursor/src/index.ts"]
+      "@ever-jobs/source-company-cursor": ["packages/source-company-cursor/src/index.ts"],
+      "@ever-jobs/source-remoteok": ["packages/source-remoteok/src/index.ts"],
+      "@ever-jobs/source-remotive": ["packages/source-remotive/src/index.ts"],
+      "@ever-jobs/source-jobicy": ["packages/source-jobicy/src/index.ts"],
+      "@ever-jobs/source-himalayas": ["packages/source-himalayas/src/index.ts"],
+      "@ever-jobs/source-arbeitnow": ["packages/source-arbeitnow/src/index.ts"],
+      "@ever-jobs/source-weworkremotely": ["packages/source-weworkremotely/src/index.ts"],
+      "@ever-jobs/source-ats-recruitee": ["packages/source-ats-recruitee/src/index.ts"],
+      "@ever-jobs/source-ats-teamtailor": ["packages/source-ats-teamtailor/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary

- Add **8 new source packages** (Tier 1 — public APIs/RSS, no auth required), expanding total sources from 26 to 34
- Add PRD document (`docs/PRD_NEW_JOB_SOURCES.md`) covering planned expansion across all tiers

### New Job Board Sources (6)
| Source | API | Notes |
|--------|-----|-------|
| **RemoteOK** | `remoteok.com/api` (JSON) | 30K+ remote jobs, salary data |
| **Remotive** | `remotive.com/api/remote-jobs` (JSON) | Remote jobs, category filtering |
| **Jobicy** | `jobicy.com/api/v2/remote-jobs` (JSON) | Remote jobs, annual salary data |
| **Himalayas** | `himalayas.app/jobs/api` (JSON) | Remote jobs, offset pagination |
| **Arbeitnow** | `arbeitnow.com/api/job-board-api` (JSON) | European job focus, page pagination |
| **We Work Remotely** | RSS feed (XML, regex-parsed) | Popular remote board |

### New ATS Sources (2)
| Source | API | Notes |
|--------|-----|-------|
| **Recruitee** | `{slug}.recruitee.com/api/offers` (JSON) | Per-company ATS, salary data |
| **Teamtailor** | `career.teamtailor.com` (JSON-API) | Per-company ATS, growing platform |

### Integration
- 8 new `Site` enum values in `site.enum.ts`
- 8 new path mappings in `tsconfig.base.json`
- All modules imported in `jobs.module.ts`
- All services wired into `jobs.service.ts` scraper map
- Recruitee & Teamtailor added to `ATS_SITES` set (require `companySlug`)

## Test plan
- [ ] Verify `tsc --noEmit` passes (confirmed locally — zero errors)
- [ ] Test RemoteOK, Remotive, Jobicy, Himalayas, Arbeitnow via search endpoint
- [ ] Test WeWorkRemotely RSS parsing via search endpoint
- [ ] Test Recruitee & Teamtailor with sample company slugs
- [ ] Verify existing 26 sources remain unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)