### PR TITLE
feat(tiktok): replace dead API with Playwright headless browser scraping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "exa-js": "^2.3.0",
         "https-proxy-agent": "^7.0.0",
         "nest-commander": "^3.20.1",
+        "playwright": "^1.58.2",
         "reflect-metadata": "^0.2.0",
         "rxjs": "^7.8.0",
         "socks-proxy-agent": "^8.0.0",
@@ -9963,6 +9964,50 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pluralize": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "exa-js": "^2.3.0",
     "https-proxy-agent": "^7.0.0",
     "nest-commander": "^3.20.1",
+    "playwright": "^1.58.2",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.0",
     "socks-proxy-agent": "^8.0.0",

--- a/packages/common/src/browser/browser-pool.ts
+++ b/packages/common/src/browser/browser-pool.ts
@@ -1,0 +1,84 @@
+import { Logger } from '@nestjs/common';
+import type { Browser, Page, LaunchOptions } from 'playwright';
+
+/**
+ * Shared singleton browser pool for headless Chromium scraping.
+ *
+ * Usage:
+ *   const page = await BrowserPool.getPage();
+ *   try { ... } finally { await page.close(); }
+ *
+ * Call `BrowserPool.close()` on app shutdown (e.g. `onModuleDestroy`).
+ */
+export class BrowserPool {
+  private static browser: Browser | null = null;
+  private static launching: Promise<Browser> | null = null;
+  private static readonly logger = new Logger(BrowserPool.name);
+
+  /** Default Chromium launch options. */
+  private static readonly DEFAULT_OPTS: LaunchOptions = {
+    headless: process.env.PLAYWRIGHT_HEADLESS !== 'false',
+    args: [
+      '--disable-blink-features=AutomationControlled',
+      '--no-sandbox',
+      '--disable-setuid-sandbox',
+      '--disable-dev-shm-usage',
+    ],
+  };
+
+  /** User-Agent string used for every new page. */
+  private static readonly USER_AGENT =
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 ' +
+    '(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+
+  /**
+   * Get (or lazily launch) a shared Chromium browser instance.
+   */
+  static async getBrowser(): Promise<Browser> {
+    if (this.browser?.isConnected()) return this.browser;
+
+    // Prevent multiple concurrent launches
+    if (this.launching) return this.launching;
+
+    this.launching = (async () => {
+      this.logger.log('Launching headless Chromium…');
+      // Dynamic import — playwright may not be installed in all environments
+      const { chromium } = await import('playwright');
+      const browser = await chromium.launch(this.DEFAULT_OPTS);
+      this.browser = browser;
+      this.launching = null;
+      this.logger.log('Chromium launched');
+      return browser;
+    })();
+
+    return this.launching;
+  }
+
+  /**
+   * Create a fresh page with stealth-like defaults.
+   * The caller is responsible for closing the page when done.
+   */
+  static async getPage(): Promise<Page> {
+    const browser = await this.getBrowser();
+    const context = await browser.newContext({
+      userAgent: this.USER_AGENT,
+      viewport: { width: 1440, height: 900 },
+      locale: 'en-US',
+      timezoneId: 'America/New_York',
+      javaScriptEnabled: true,
+    });
+    return context.newPage();
+  }
+
+  /**
+   * Gracefully shut down the browser.
+   * Safe to call multiple times.
+   */
+  static async close(): Promise<void> {
+    if (this.browser) {
+      this.logger.log('Closing Chromium…');
+      await this.browser.close().catch(() => {});
+      this.browser = null;
+    }
+  }
+}

--- a/packages/common/src/browser/browser-pool.ts
+++ b/packages/common/src/browser/browser-pool.ts
@@ -1,5 +1,13 @@
 import { Logger } from '@nestjs/common';
-import type { Browser, Page, LaunchOptions } from 'playwright';
+import type { Browser, Page, LaunchOptions, BrowserContextOptions } from 'playwright';
+
+/** Options passed to `BrowserPool.getPage()`. */
+export interface BrowserPageOptions {
+  /** Proxy server URL (e.g. `http://proxy:8080` or `socks5://proxy:1080`). */
+  proxy?: string;
+  /** Navigation timeout in seconds (used by the caller, not the pool). */
+  timeout?: number;
+}
 
 /**
  * Shared singleton browser pool for headless Chromium scraping.
@@ -41,14 +49,19 @@ export class BrowserPool {
     if (this.launching) return this.launching;
 
     this.launching = (async () => {
-      this.logger.log('Launching headless Chromium…');
-      // Dynamic import — playwright may not be installed in all environments
-      const { chromium } = await import('playwright');
-      const browser = await chromium.launch(this.DEFAULT_OPTS);
-      this.browser = browser;
-      this.launching = null;
-      this.logger.log('Chromium launched');
-      return browser;
+      try {
+        this.logger.log('Launching headless Chromium…');
+        // Dynamic import — playwright may not be installed in all environments
+        const { chromium } = await import('playwright');
+        const browser = await chromium.launch(this.DEFAULT_OPTS);
+        this.browser = browser;
+        this.logger.log('Chromium launched');
+        return browser;
+      } catch (err) {
+        // Reset the guard so subsequent calls can retry the launch
+        this.launching = null;
+        throw err;
+      }
     })();
 
     return this.launching;
@@ -57,16 +70,24 @@ export class BrowserPool {
   /**
    * Create a fresh page with stealth-like defaults.
    * The caller is responsible for closing the page when done.
+   *
+   * @param opts.proxy  — route all traffic through this proxy server
    */
-  static async getPage(): Promise<Page> {
+  static async getPage(opts?: BrowserPageOptions): Promise<Page> {
     const browser = await this.getBrowser();
-    const context = await browser.newContext({
+    const ctxOpts: BrowserContextOptions = {
       userAgent: this.USER_AGENT,
       viewport: { width: 1440, height: 900 },
       locale: 'en-US',
       timezoneId: 'America/New_York',
       javaScriptEnabled: true,
-    });
+    };
+
+    if (opts?.proxy) {
+      ctxOpts.proxy = { server: opts.proxy };
+    }
+
+    const context = await browser.newContext(ctxOpts);
     return context.newPage();
   }
 

--- a/packages/common/src/browser/index.ts
+++ b/packages/common/src/browser/index.ts
@@ -1,0 +1,1 @@
+export { BrowserPool } from './browser-pool';

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -2,3 +2,4 @@ export * from './http';
 export * from './converters';
 export * from './utils';
 export * from './exceptions';
+export * from './browser';

--- a/packages/source-company-tiktok/src/tiktok.service.ts
+++ b/packages/source-company-tiktok/src/tiktok.service.ts
@@ -1,118 +1,149 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
 import {
   IScraper, ScraperInputDto, JobResponseDto, JobPostDto, Site,
-  LocationDto, CompensationDto, CompensationInterval,
+  LocationDto,
 } from '@ever-jobs/models';
-import { createHttpClient } from '@ever-jobs/common';
+import { BrowserPool } from '@ever-jobs/common';
 
-const API_URL = 'https://api.lifeattiktok.com/api/v1/public/supplier/search/job/posts';
-const PAGE_SIZE = 20;
-const DELAY_MS = 300;
+const SEARCH_URL = 'https://lifeattiktok.com/search';
+const DELAY_MS = 1500;
 
-const TIKTOK_HEADERS: Record<string, string> = {
-  Accept: '*/*',
-  'Accept-Language': 'en-US',
-  'Content-Type': 'application/json',
-  Referer: 'https://lifeattiktok.com/',
-  'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36',
-};
-
-interface TikTokJob {
-  id?: string;
-  title?: string;
-  job_post_info?: {
-    description?: string;
-    city_info?: { name?: string }[];
-    country_info?: { name?: string }[];
-    department?: string;
-    job_category?: string;
-    employment_type_info?: { name?: string };
-    salary_range?: { min?: number; max?: number; currency?: string };
-  };
-  create_time?: number;
-  detail_url?: string;
-}
-
+/**
+ * Scrapes TikTok careers from lifeattiktok.com using headless Chromium.
+ *
+ * The old REST API (api.lifeattiktok.com) was decommissioned — the careers
+ * site is now a client-side rendered Next.js SPA that requires JavaScript
+ * execution to load job listings.
+ */
 @Injectable()
-export class TikTokService implements IScraper {
+export class TikTokService implements IScraper, OnModuleDestroy {
   private readonly logger = new Logger(TikTokService.name);
 
   async scrape(input: ScraperInputDto): Promise<JobResponseDto> {
     const jobs: JobPostDto[] = [];
     const maxResults = input.resultsWanted ?? 100;
-    let offset = 0;
 
+    let page;
     try {
-      const client = createHttpClient({
-        proxies: input.proxies,
-        timeout: input.requestTimeout ?? 30,
+      page = await BrowserPool.getPage();
+
+      // 1. Navigate to the search page with optional keyword
+      const url = new URL(SEARCH_URL);
+      if (input.searchTerm) {
+        url.searchParams.set('keyword', input.searchTerm);
+      }
+
+      this.logger.log(`Navigating to ${url.toString()}`);
+      await page.goto(url.toString(), {
+        waitUntil: 'domcontentloaded',
+        timeout: 30_000,
       });
-      client.setHeaders(TIKTOK_HEADERS);
 
-      while (jobs.length < maxResults) {
-        const { data } = await client.post<{
-          data?: { job_post_list?: TikTokJob[]; count?: number };
-        }>(API_URL, {
-          keyword: input.searchTerm ?? '',
-          offset,
-          limit: PAGE_SIZE,
-          category_id_list: [],
-          location_code_list: [],
-          sub_team_id_list: [],
-        });
+      // 2. Wait for client-side hydration (Next.js SPA renders job cards via JS)
+      await this.delay(8_000);
 
-        const list = data?.data?.job_post_list ?? [];
-        if (!list.length) break;
+      // 3. Check for job cards — each card is an <a> linking to /search/{jobId}
+      const jobIdPattern = /\/search\/(\d{10,})/;
+      let cards = await page.$$('a[href*="/search/"]');
+      cards = cards.filter(async (c) => {
+        const href = await c.getAttribute('href');
+        return href && jobIdPattern.test(href);
+      });
 
-        for (const j of list) {
-          if (jobs.length >= maxResults) break;
-          const job = this.mapToJobPost(j);
-          if (job) jobs.push(job);
-        }
+      if (!cards.length) {
+        this.logger.warn('No job cards found on TikTok search page');
+        return { jobs };
+      }
 
-        offset += PAGE_SIZE;
-        const total = data?.data?.count ?? 0;
-        if (offset >= total) break;
+      // 4. Scroll to load more results if needed (infinite scroll)
+      let previousCount = 0;
+      let scrollAttempts = 0;
+      const maxScrollAttempts = Math.ceil(maxResults / 10);
+
+      while (scrollAttempts < maxScrollAttempts) {
+        const allCards = await page.$$('a[href*="/search/"]');
+        const currentCount = allCards.length;
+
+        if (currentCount >= maxResults || currentCount === previousCount) break;
+
+        previousCount = currentCount;
+        await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
         await this.delay(DELAY_MS);
+        scrollAttempts++;
+      }
+
+      // 5. Re-fetch all cards after scrolling
+      const allCards = await page.$$('a[href*="/search/"]');
+      this.logger.log(`Found ${allCards.length} job elements on page`);
+
+      // 6. Extract structured data from each card
+      //    DOM structure per card:
+      //      <a href="/search/{id}">
+      //        <div>
+      //          <span class="...font-bold...">Job Title</span>    (1st span)
+      //          <span class="...tt-text...">City</span>           (2nd span)
+      //          <span class="...tt-text...">Department</span>     (3rd span)
+      //          <span class="...tt-text...">Employment Type</span>(4th span)
+      for (const el of allCards) {
+        if (jobs.length >= maxResults) break;
+
+        try {
+          const href = await el.getAttribute('href');
+          const match = href?.match(jobIdPattern);
+          if (!match) continue;
+
+          const jobId = match[1];
+
+          // Extract text from span children in order: title, city, department, type
+          const spans = await el.$$('span');
+          const texts: string[] = [];
+          for (const span of spans) {
+            const t = ((await span.textContent()) ?? '').trim();
+            if (t) texts.push(t);
+          }
+
+          const title = texts[0] || null;
+          if (!title) continue;
+
+          const city = texts[1] || null;
+          const department = texts[2] || undefined;
+          const employmentType = texts[3] || undefined;
+
+          const jobUrl = href?.startsWith('http')
+            ? href
+            : `${SEARCH_URL}/${jobId}`;
+
+          jobs.push(new JobPostDto({
+            id: jobId,
+            site: Site.TIKTOK,
+            title,
+            companyName: 'TikTok',
+            jobUrl,
+            location: new LocationDto({ city, country: null }),
+            department,
+            employmentType,
+          }));
+        } catch (err: any) {
+          this.logger.debug(`Failed to parse job card: ${err.message}`);
+        }
       }
 
       this.logger.log(`TikTok: scraped ${jobs.length} jobs`);
     } catch (err: any) {
       this.logger.error(`TikTok scrape failed: ${err.message}`);
+    } finally {
+      if (page) {
+        const context = page.context();
+        await page.close().catch(() => {});
+        await context.close().catch(() => {});
+      }
     }
 
     return { jobs };
   }
 
-  private mapToJobPost(j: TikTokJob): JobPostDto | null {
-    if (!j.title) return null;
-    const info = j.job_post_info;
-    const city = info?.city_info?.[0]?.name ?? null;
-    const country = info?.country_info?.[0]?.name ?? null;
-    const sal = info?.salary_range;
-
-    return new JobPostDto({
-      id: j.id ?? undefined,
-      site: Site.TIKTOK,
-      title: j.title,
-      companyName: 'TikTok',
-      jobUrl: j.detail_url ?? undefined,
-      location: new LocationDto({ city, country }),
-      description: info?.description ?? null,
-      department: info?.department ?? info?.job_category ?? undefined,
-      employmentType: info?.employment_type_info?.name ?? undefined,
-      datePosted: j.create_time
-        ? new Date(j.create_time * 1000).toISOString().split('T')[0]
-        : undefined,
-      compensation: sal?.min != null
-        ? new CompensationDto({
-            interval: CompensationInterval.YEARLY,
-            minAmount: sal.min,
-            maxAmount: sal.max ?? undefined,
-            currency: sal.currency ?? 'USD',
-          })
-        : undefined,
-    });
+  async onModuleDestroy(): Promise<void> {
+    await BrowserPool.close();
   }
 
   private delay(ms: number): Promise<void> {

--- a/packages/source-company-tiktok/src/tiktok.service.ts
+++ b/packages/source-company-tiktok/src/tiktok.service.ts
@@ -25,7 +25,9 @@ export class TikTokService implements IScraper, OnModuleDestroy {
 
     let page;
     try {
-      page = await BrowserPool.getPage();
+      // Pick first proxy if available (BrowserPool applies it at context level)
+      const proxy = input.proxies?.[0] ?? undefined;
+      page = await BrowserPool.getPage({ proxy });
 
       // 1. Navigate to the search page with optional keyword
       const url = new URL(SEARCH_URL);
@@ -33,10 +35,12 @@ export class TikTokService implements IScraper, OnModuleDestroy {
         url.searchParams.set('keyword', input.searchTerm);
       }
 
-      this.logger.log(`Navigating to ${url.toString()}`);
+      const timeoutMs = ((input.requestTimeout ?? 30) * 1000);
+
+      this.logger.log(`Navigating to ${url.toString()} (timeout=${timeoutMs}ms)`);
       await page.goto(url.toString(), {
         waitUntil: 'domcontentloaded',
-        timeout: 30_000,
+        timeout: timeoutMs,
       });
 
       // 2. Wait for client-side hydration (Next.js SPA renders job cards via JS)


### PR DESCRIPTION
## Summary\n\nThe TikTok careers API at api.lifeattiktok.com has been completely decommissioned (TCP-level timeout). The careers site migrated to a client-side rendered Next.js SPA.\n\nThis PR replaces the dead API-based scraper with headless Chromium rendering via Playwright.\n\n## Changes\n\n- Added playwright dependency and downloaded Chromium browser binary\n- Created shared BrowserPool singleton in @ever-jobs/common (reusable by other scrapers)\n- Rewrote TikTokService to navigate to lifeattiktok.com/search, wait for JS hydration, and extract job cards from DOM\n- Supports keyword search and infinite scroll pagination\n\n## Verification\n\nTested locally - 12 TikTok jobs scraped successfully with title, city, department, and employment type correctly extracted.