### PR TITLE
docs: add per-request auth override to changelog and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,7 +571,7 @@ India-specific. Supports both internships and full-time jobs. Extracts stipend, 
 
 ### Exa
 
-Global AI-powered job search via the [Exa API](https://exa.ai). Requires `EXA_API_KEY` environment variable.
+Global AI-powered job search via the [Exa API](https://exa.ai). Requires `EXA_API_KEY` environment variable. Credentials can also be passed per-request via the `auth.exa` field in the request body.
 
 ### Upwork
 
@@ -626,23 +626,23 @@ Teamtailor ATS integration. Per-company career page API. Requires `companySlug` 
 
 ### USAJobs
 
-US government job board with free API. Requires `USAJOBS_API_KEY` and `USAJOBS_EMAIL` environment variables. Register at [developer.usajobs.gov](https://developer.usajobs.gov/APIRequest/Index). Returns full descriptions with salary data from position remuneration fields.
+US government job board with free API. Requires `USAJOBS_API_KEY` and `USAJOBS_EMAIL` environment variables. Register at [developer.usajobs.gov](https://developer.usajobs.gov/APIRequest/Index). Returns full descriptions with salary data from position remuneration fields. Credentials can also be passed per-request via the `auth.usajobs` field in the request body.
 
 ### Adzuna
 
-Multi-country job aggregator covering 12+ countries. Requires `ADZUNA_APP_ID` and `ADZUNA_APP_KEY` environment variables. Register at [developer.adzuna.com](https://developer.adzuna.com/signup). Free tier limited to 25 requests/min and 250 requests/day. Uses the `country` parameter to select the appropriate API endpoint.
+Multi-country job aggregator covering 12+ countries. Requires `ADZUNA_APP_ID` and `ADZUNA_APP_KEY` environment variables. Register at [developer.adzuna.com](https://developer.adzuna.com/signup). Free tier limited to 25 requests/min and 250 requests/day. Uses the `country` parameter to select the appropriate API endpoint. Credentials can also be passed per-request via the `auth.adzuna` field in the request body.
 
 ### Reed
 
-UK-focused job board. Requires `REED_API_KEY` environment variable. Register at [reed.co.uk/developers](https://www.reed.co.uk/developers). Uses HTTP Basic Auth. Provides salary data in GBP.
+UK-focused job board. Requires `REED_API_KEY` environment variable. Register at [reed.co.uk/developers](https://www.reed.co.uk/developers). Uses HTTP Basic Auth. Provides salary data in GBP. Credentials can also be passed per-request via the `auth.reed` field in the request body.
 
 ### Jooble
 
-Job aggregator covering 70+ countries. Requires `JOOBLE_API_KEY` environment variable. Register at [jooble.org/api/about](https://jooble.org/api/about). Uses POST requests with the API key in the URL path. Salary data parsed from string format.
+Job aggregator covering 70+ countries. Requires `JOOBLE_API_KEY` environment variable. Register at [jooble.org/api/about](https://jooble.org/api/about). Uses POST requests with the API key in the URL path. Salary data parsed from string format. Credentials can also be passed per-request via the `auth.jooble` field in the request body.
 
 ### CareerJet
 
-Job aggregator covering 80+ countries with locale-based searches. Requires `CAREERJET_AFFID` environment variable. Register at [careerjet.com/partners](https://www.careerjet.com/partners/). Requires `clientIp` parameter for proper operation (falls back to `127.0.0.1`). Supports the `proxies` parameter for residential IP rotation.
+Job aggregator covering 80+ countries with locale-based searches. Requires `CAREERJET_AFFID` environment variable. Register at [careerjet.com/partners](https://www.careerjet.com/partners/). Requires `clientIp` parameter for proper operation (falls back to `127.0.0.1`). Supports the `proxies` parameter for residential IP rotation. Credentials can also be passed per-request via the `auth.careerjet` field in the request body.
 
 ---
 

--- a/docs/API_CHANGELOG.md
+++ b/docs/API_CHANGELOG.md
@@ -22,6 +22,14 @@ Total sources expanded from 34 to 39.
 
 - `clientIp` — Optional client IP address for sources that require it (e.g. CareerJet). Also useful for residential proxy rotation strategies. Combined with the existing `proxies` array for multi-IP support.
 
+### Per-Request Auth Override
+
+All API-key sources now support per-request credential override via `auth` in the request body, following the existing Upwork pattern. This allows clients to use their own API keys instead of (or in addition to) server-side environment variables.
+
+New `auth` sub-objects: `auth.usajobs`, `auth.adzuna`, `auth.reed`, `auth.jooble`, `auth.careerjet`, `auth.exa`
+
+Each credential field resolves independently — callers can override individual fields while keeping others from env vars (e.g. override `auth.usajobs.apiKey` but keep `email` from `USAJOBS_EMAIL`).
+
 ## [0.1.1] — 2026-02-14
 
 ### New Sources (8)


### PR DESCRIPTION
## Summary

- Update `API_CHANGELOG.md` with per-request auth override section (new `auth` sub-objects for all 6 API-key sources)
- Update `README.md` source descriptions to mention per-request auth support for USAJobs, Adzuna, Reed, Jooble, CareerJet, and Exa

Follow-up to PR #3 which added the per-request auth feature but didn't include documentation updates.

## Test plan

- [ ] Verify changelog accurately describes `auth.usajobs`, `auth.adzuna`, `auth.reed`, `auth.jooble`, `auth.careerjet`, `auth.exa` sub-objects
- [ ] Verify README source descriptions mention per-request auth availability

🤖 Generated with [Claude Code](https://claude.com/claude-code)