### PR TITLE
fix(adzuna,jooble): use correct currency and interval for salary data

### DIFF
--- a/packages/source-adzuna/src/adzuna.constants.ts
+++ b/packages/source-adzuna/src/adzuna.constants.ts
@@ -44,3 +44,22 @@ export const COUNTRY_TO_ADZUNA: Partial<Record<Country, string>> = {
  * Default Adzuna country code when no mapping is found.
  */
 export const ADZUNA_DEFAULT_COUNTRY = 'us';
+
+/**
+ * Map Adzuna 2-letter country codes to their local currency (ISO 4217).
+ * Adzuna returns salaries in local currency for each country endpoint.
+ */
+export const ADZUNA_COUNTRY_CURRENCY: Record<string, string> = {
+  us: 'USD',
+  gb: 'GBP',
+  au: 'AUD',
+  ca: 'CAD',
+  de: 'EUR',
+  fr: 'EUR',
+  at: 'EUR',
+  in: 'INR',
+  pl: 'PLN',
+  br: 'BRL',
+  nz: 'NZD',
+  za: 'ZAR',
+};

--- a/packages/source-adzuna/src/adzuna.service.ts
+++ b/packages/source-adzuna/src/adzuna.service.ts
@@ -26,6 +26,7 @@ import {
   ADZUNA_RATE_LIMIT_PER_MINUTE,
   COUNTRY_TO_ADZUNA,
   ADZUNA_DEFAULT_COUNTRY,
+  ADZUNA_COUNTRY_CURRENCY,
 } from './adzuna.constants';
 import { AdzunaResponse, AdzunaJob } from './adzuna.types';
 
@@ -139,7 +140,7 @@ export class AdzunaService implements IScraper {
           seenIds.add(jobId);
 
           try {
-            const job = this.mapJob(raw, input.descriptionFormat);
+            const job = this.mapJob(raw, countryCode, input.descriptionFormat);
             if (job) jobs.push(job);
           } catch (err: any) {
             this.logger.warn(`Error mapping Adzuna job ${jobId}: ${err.message}`);
@@ -170,7 +171,7 @@ export class AdzunaService implements IScraper {
   /**
    * Map an Adzuna job result to a JobPostDto.
    */
-  private mapJob(raw: AdzunaJob, descriptionFormat?: DescriptionFormat): JobPostDto | null {
+  private mapJob(raw: AdzunaJob, countryCode: string, descriptionFormat?: DescriptionFormat): JobPostDto | null {
     // jobUrl is REQUIRED — skip if missing
     const jobUrl = raw.redirect_url;
     if (!jobUrl) return null;
@@ -206,7 +207,7 @@ export class AdzunaService implements IScraper {
           interval: CompensationInterval.YEARLY,
           minAmount: hasMin ? raw.salary_min : null,
           maxAmount: hasMax ? raw.salary_max : null,
-          currency: 'USD',
+          currency: ADZUNA_COUNTRY_CURRENCY[countryCode] ?? 'USD',
         });
       }
     }

--- a/packages/source-jooble/src/jooble.service.ts
+++ b/packages/source-jooble/src/jooble.service.ts
@@ -24,8 +24,25 @@ import {
 } from './jooble.constants';
 import { JoobleResponse, JoobleJob } from './jooble.types';
 
-/** Safe regex for parsing salary ranges like "$80,000 - $120,000" */
-const SALARY_RANGE_REGEX = /\$?(\d{1,3}(?:,\d{3})*|\d+)\s*[-\u2013]\s*\$?(\d{1,3}(?:,\d{3})*|\d+)/;
+/** Safe regex for parsing salary ranges like "$80,000 - $120,000" or "€3,000 - €5,000" */
+const SALARY_RANGE_REGEX = /[$€£₹]?\s*(\d{1,3}(?:,\d{3})*|\d+)\s*[-\u2013]\s*[$€£₹]?\s*(\d{1,3}(?:,\d{3})*|\d+)/;
+
+/** Map currency symbols found in salary strings to ISO 4217 codes */
+const CURRENCY_SYMBOL_MAP: Record<string, string> = {
+  '$': 'USD',
+  '\u20AC': 'EUR', // €
+  '\u00A3': 'GBP', // £
+  '\u20B9': 'INR', // ₹
+};
+
+/** Match interval keywords in salary strings */
+const INTERVAL_KEYWORDS: Array<[RegExp, CompensationInterval]> = [
+  [/\b(?:per\s+hour|\/\s*hr|hourly|\/\s*hour)\b/i, CompensationInterval.HOURLY],
+  [/\b(?:per\s+day|\/\s*day|daily)\b/i, CompensationInterval.DAILY],
+  [/\b(?:per\s+week|\/\s*wk|weekly)\b/i, CompensationInterval.WEEKLY],
+  [/\b(?:per\s+month|\/\s*mo|monthly|p\.?\s*m\.?)\b/i, CompensationInterval.MONTHLY],
+  [/\b(?:per\s+year|\/\s*yr|yearly|annual|annually|p\.?\s*a\.?)\b/i, CompensationInterval.YEARLY],
+];
 
 @Injectable()
 export class JoobleService implements IScraper {
@@ -185,10 +202,18 @@ export class JoobleService implements IScraper {
 
   /**
    * Parse a salary string into a CompensationDto.
-   * Handles formats like "$80,000 - $120,000", "80000", or empty strings.
+   * Detects currency from symbols ($, €, £, ₹) and interval from keywords
+   * (hourly, monthly, yearly, etc.). Falls back to null currency / yearly interval
+   * when the string doesn't contain enough hints.
    */
   private parseSalary(salary: string): CompensationDto | null {
     if (!salary || !salary.trim()) return null;
+
+    // Detect currency from symbol
+    const currency = this.detectCurrency(salary);
+
+    // Detect interval from keywords
+    const interval = this.detectInterval(salary);
 
     const rangeMatch = salary.match(SALARY_RANGE_REGEX);
     if (rangeMatch) {
@@ -196,28 +221,50 @@ export class JoobleService implements IScraper {
       const maxAmount = parseInt(rangeMatch[2].replace(/,/g, ''), 10);
       if (!isNaN(minAmount) && !isNaN(maxAmount)) {
         return new CompensationDto({
-          interval: CompensationInterval.YEARLY,
+          interval,
           minAmount,
           maxAmount,
-          currency: 'USD',
+          currency,
         });
       }
     }
 
     // Try to parse a single number
-    const singleMatch = salary.match(/\$?(\d{1,3}(?:,\d{3})*|\d+)/);
+    const singleMatch = salary.match(/[$€£₹]?\s*(\d{1,3}(?:,\d{3})*|\d+)/);
     if (singleMatch) {
       const amount = parseInt(singleMatch[1].replace(/,/g, ''), 10);
       if (!isNaN(amount) && amount > 0) {
         return new CompensationDto({
-          interval: CompensationInterval.YEARLY,
+          interval,
           minAmount: amount,
           maxAmount: null,
-          currency: 'USD',
+          currency,
         });
       }
     }
 
     return null;
+  }
+
+  /**
+   * Detect ISO 4217 currency code from a salary string's symbol.
+   * Returns null when no recognizable symbol is found.
+   */
+  private detectCurrency(salary: string): string | undefined {
+    for (const [symbol, code] of Object.entries(CURRENCY_SYMBOL_MAP)) {
+      if (salary.includes(symbol)) return code;
+    }
+    return undefined; // let CompensationDto default handle it
+  }
+
+  /**
+   * Detect compensation interval from keywords in a salary string.
+   * Returns YEARLY as the default when no interval hint is found.
+   */
+  private detectInterval(salary: string): CompensationInterval {
+    for (const [pattern, interval] of INTERVAL_KEYWORDS) {
+      if (pattern.test(salary)) return interval;
+    }
+    return CompensationInterval.YEARLY;
   }
 }


### PR DESCRIPTION
## Summary

- **Adzuna**: Salary currency now derived from the country endpoint (`GBP` for `gb`, `EUR` for `de`/`fr`/`at`, `INR` for `in`, `PLN` for `pl`, etc.) instead of hardcoding `USD` for all 12 supported countries. Added `ADZUNA_COUNTRY_CURRENCY` map to constants and passed `countryCode` through to `mapJob()`.

- **Jooble**: Salary parser now detects currency symbols (`$` → USD, `€` → EUR, `£` → GBP, `₹` → INR) and interval keywords (`per hour`, `monthly`, `yearly`, `/hr`, `p.a.`, etc.) from the salary string. Previously all salaries were assumed USD yearly regardless of content.

## Test plan

- [ ] Verify Adzuna UK search returns `GBP` currency, not `USD`
- [ ] Verify Adzuna Germany search returns `EUR` currency
- [ ] Verify Adzuna US search still returns `USD` (default behavior preserved)
- [ ] Verify Jooble salary string `"£30,000 - £40,000"` parses as GBP
- [ ] Verify Jooble salary string `"$25/hr"` parses as USD hourly
- [ ] Verify Jooble salary string `"80000"` still parses as yearly (default interval preserved)
- [ ] `npx tsc -p tsconfig.base.json --noEmit` passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)