### PR TITLE
feat: add 7 new job sources (Tier 2 — Phase 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 
 ## ⭐️ Overview
 
-**Ever Jobs** searches job postings from **39 sources** concurrently and returns aggregated, normalized results through a single REST API **or CLI**. Sources span search-based job boards, ATS (Applicant Tracking System) boards, and company-specific career APIs. Each source is an independent, reusable NestJS package — making it easy to add new sources, consume individual packages in other projects, or deploy the full API.
+**Ever Jobs** searches job postings from **46 sources** concurrently and returns aggregated, normalized results through a single REST API **or CLI**. Sources span search-based job boards, ATS (Applicant Tracking System) boards, and company-specific career APIs. Each source is an independent, reusable NestJS package — making it easy to add new sources, consume individual packages in other projects, or deploy the full API.
 
-### Search-Based Job Boards (22)
+### Search-Based Job Boards (26)
 
 | Source                 | Method                 | Region                      |
 | ---------------------- | ---------------------- | --------------------------- |
@@ -37,8 +37,12 @@
 | **Reed**               | REST API (API key)     | UK                          |
 | **Jooble**             | REST API (API key)     | 70+ countries               |
 | **CareerJet**          | REST API (affiliate)   | 80+ countries               |
+| **Dice**               | HTML + Playwright      | US (tech jobs)              |
+| **SimplyHired**        | HTML + Playwright      | Global                      |
+| **Wellfound**          | Playwright SPA         | Global (startups)           |
+| **StepStone**          | Playwright SPA         | Germany                     |
 
-### ATS Job Boards (9)
+### ATS Job Boards (12)
 
 ATS scrapers require a `companySlug` to target a specific company's job board.
 
@@ -53,6 +57,9 @@ ATS scrapers require a `companySlug` to target a specific company's job board.
 | **Workday**         | Workday         | REST API    |
 | **Recruitee**       | Recruitee       | REST API    |
 | **Teamtailor**      | Teamtailor      | REST API    |
+| **BambooHR**        | BambooHR        | REST API (JSON) |
+| **Personio**        | Personio        | XML feed        |
+| **JazzHR**          | JazzHR          | HTML scraping   |
 
 ### Company-Specific Scrapers (7)
 
@@ -72,7 +79,7 @@ Direct integrations with major tech companies' career APIs.
 
 ## ✨ Features
 
-- 🔍 **Multi-source aggregation** — Search 1 or all 39 sources concurrently
+- 🔍 **Multi-source aggregation** — Search 1 or all 46 sources concurrently
 - 🖥️ **CLI & API** — Use via REST API or command-line with JSON, CSV, table, or summary output
 - 🌐 **Country-aware** — Indeed & Glassdoor support 65+ countries with automatic domain resolution
 - 🔄 **Proxy rotation** — Built-in rotating proxy support (HTTP, HTTPS, SOCKS5)

--- a/apps/api/src/jobs/jobs.module.ts
+++ b/apps/api/src/jobs/jobs.module.ts
@@ -37,6 +37,13 @@ import { AdzunaModule } from '@ever-jobs/source-adzuna';
 import { ReedModule } from '@ever-jobs/source-reed';
 import { JoobleModule } from '@ever-jobs/source-jooble';
 import { CareerJetModule } from '@ever-jobs/source-careerjet';
+import { BambooHRModule } from '@ever-jobs/source-ats-bamboohr';
+import { PersonioModule } from '@ever-jobs/source-ats-personio';
+import { JazzHRModule } from '@ever-jobs/source-ats-jazzhr';
+import { DiceModule } from '@ever-jobs/source-dice';
+import { SimplyHiredModule } from '@ever-jobs/source-simplyhired';
+import { WellfoundModule } from '@ever-jobs/source-wellfound';
+import { StepStoneModule } from '@ever-jobs/source-stepstone';
 import { AnalyticsModule } from '@ever-jobs/analytics';
 import { JobsController } from './jobs.controller';
 import { JobsService } from './jobs.service';
@@ -81,6 +88,13 @@ import { JobsService } from './jobs.service';
     ReedModule,
     JoobleModule,
     CareerJetModule,
+    BambooHRModule,
+    PersonioModule,
+    JazzHRModule,
+    DiceModule,
+    SimplyHiredModule,
+    WellfoundModule,
+    StepStoneModule,
     AnalyticsModule,
   ],
   controllers: [JobsController],

--- a/apps/api/src/jobs/jobs.service.ts
+++ b/apps/api/src/jobs/jobs.service.ts
@@ -42,6 +42,13 @@ import { AdzunaService } from '@ever-jobs/source-adzuna';
 import { ReedService } from '@ever-jobs/source-reed';
 import { JoobleService } from '@ever-jobs/source-jooble';
 import { CareerJetService } from '@ever-jobs/source-careerjet';
+import { BambooHRService } from '@ever-jobs/source-ats-bamboohr';
+import { PersonioService } from '@ever-jobs/source-ats-personio';
+import { JazzHRService } from '@ever-jobs/source-ats-jazzhr';
+import { DiceService } from '@ever-jobs/source-dice';
+import { SimplyHiredService } from '@ever-jobs/source-simplyhired';
+import { WellfoundService } from '@ever-jobs/source-wellfound';
+import { StepStoneService } from '@ever-jobs/source-stepstone';
 
 @Injectable()
 export class JobsService {
@@ -87,6 +94,13 @@ export class JobsService {
     private readonly reedService: ReedService,
     private readonly joobleService: JoobleService,
     private readonly careerJetService: CareerJetService,
+    private readonly bambooHRService: BambooHRService,
+    private readonly personioService: PersonioService,
+    private readonly jazzHRService: JazzHRService,
+    private readonly diceService: DiceService,
+    private readonly simplyHiredService: SimplyHiredService,
+    private readonly wellfoundService: WellfoundService,
+    private readonly stepStoneService: StepStoneService,
   ) {
     this.scraperMap = new Map<Site, IScraper>([
       [Site.LINKEDIN, this.linkedInService],
@@ -127,6 +141,13 @@ export class JobsService {
       [Site.REED, this.reedService],
       [Site.JOOBLE, this.joobleService],
       [Site.CAREERJET, this.careerJetService],
+      [Site.BAMBOOHR, this.bambooHRService],
+      [Site.PERSONIO, this.personioService],
+      [Site.JAZZHR, this.jazzHRService],
+      [Site.DICE, this.diceService],
+      [Site.SIMPLYHIRED, this.simplyHiredService],
+      [Site.WELLFOUND, this.wellfoundService],
+      [Site.STEPSTONE, this.stepStoneService],
     ]);
   }
 
@@ -142,6 +163,9 @@ export class JobsService {
     Site.WORKDAY,
     Site.RECRUITEE,
     Site.TEAMTAILOR,
+    Site.BAMBOOHR,
+    Site.PERSONIO,
+    Site.JAZZHR,
   ]);
 
   /** Company scrapers target a single company's career API directly */

--- a/docs/API_CHANGELOG.md
+++ b/docs/API_CHANGELOG.md
@@ -1,5 +1,39 @@
 # API Changelog
 
+## [0.3.0] — 2026-02-15
+
+### New Sources (7)
+
+Added 7 new job source integrations (Tier 2 — HTML scraping / Playwright):
+
+**ATS (3):**
+- **BambooHR** — Public JSON API, `{companySlug}.bamboohr.com/careers/list`
+- **Personio** — Public XML feed, `{companySlug}.jobs.personio.de/xml`
+- **JazzHR** *(WIP)* — HTML scraping, `{companySlug}.applytojob.com/apply/jobs/`
+
+**Job Boards (4):**
+- **Dice** *(WIP)* — Cheerio + Playwright fallback, US tech jobs
+- **SimplyHired** *(WIP)* — Cheerio + Playwright fallback, global
+- **Wellfound** *(WIP)* — Playwright SPA (`__NEXT_DATA__` extraction), startup jobs
+- **StepStone** *(WIP)* — Playwright SPA, Germany (`.de`) initially
+
+Total sources expanded from 39 to 46.
+
+### New `siteType` Values
+
+- `bamboohr`, `personio`, `jazzhr` — ATS sources (require `companySlug` parameter)
+- `dice`, `simplyhired`, `wellfound`, `stepstone` — search-based job boards (included in default searches)
+
+### Proxy Support
+
+All 7 sources wire proxies through:
+- HTTP sources: via `createHttpClient({ proxies })`
+- Playwright sources: via `BrowserPool.getPage({ proxy })`
+
+### WIP Sources Note
+
+5 of 7 sources are marked WIP — code is shipped but HTML selectors need validation against live sites. These sources will gracefully return empty results if selectors are outdated.
+
 ## [0.2.0] — 2026-02-14
 
 ### New Sources (5)

--- a/docs/PRD_NEW_JOB_SOURCES.md
+++ b/docs/PRD_NEW_JOB_SOURCES.md
@@ -2,14 +2,14 @@
 
 **Author:** AI Assistant
 **Date:** 2026-02-14
-**Status:** Phase 2 Complete
+**Status:** Phase 3 In Progress
 **Epic:** Source Expansion
 
 ---
 
 ## 1. Overview
 
-Expand ever-jobs from **26 sources** to **39 sources** by adding new job boards and ATS integrations. Phase 1 added 8 public API/RSS sources (Tier 1), Phase 2 added 5 API-key sources (Tier 1.5).
+Expand ever-jobs from **26 sources** to **46 sources** by adding new job boards and ATS integrations. Phase 1 added 8 public API/RSS sources (Tier 1), Phase 2 added 5 API-key sources (Tier 1.5), Phase 3 adds 7 HTML scraping / semi-public API sources (Tier 2).
 
 ### Current Sources (26)
 
@@ -132,7 +132,7 @@ These 8 sources have free, unauthenticated APIs or RSS feeds. They follow existi
 
 ## 3. Future Tiers (Planned)
 
-### Tier 1.5 - Free API Key Required
+### Tier 1.5 - Free API Key Required (Phase 2 - Complete)
 
 | Source | Type | Notes |
 |--------|------|-------|
@@ -142,21 +142,21 @@ These 8 sources have free, unauthenticated APIs or RSS feeds. They follow existi
 | Jooble | Aggregator | Free developer API |
 | CareerJet | Aggregator | Free webmaster API |
 
-### Tier 2 - HTML Scraping (Medium)
+### Tier 2 - HTML Scraping (Phase 3 - In Progress)
 
-| Source | Type | Notes |
-|--------|------|-------|
-| Wellfound (AngelList) | Job Board | Startups, salary/equity |
-| StepStone | Job Board | Major European board |
-| Dice | Job Board | Tech-focused, 70K+ jobs |
-| SimplyHired | Job Board | Standard HTML |
-| JazzHR | ATS | Clean career pages |
-| Personio | ATS | European HR platform |
-| BambooHR | ATS | Per-company API |
-| Comeet | ATS | Clean HTML |
-| Pinpoint | ATS | Clean HTML |
+| Source | Type | Package | Status | Notes |
+|--------|------|---------|--------|-------|
+| BambooHR | ATS | `source-ats-bamboohr` | Complete | Public JSON API at `{slug}.bamboohr.com/careers/list` |
+| Personio | ATS | `source-ats-personio` | Complete | Public XML feed at `{slug}.jobs.personio.de/xml` |
+| JazzHR | ATS | `source-ats-jazzhr` | WIP | HTML scraping; TODO: validate selectors against live career pages |
+| Dice | Job Board | `source-dice` | WIP | Cheerio + Playwright fallback; TODO: validate selectors against live pages |
+| SimplyHired | Job Board | `source-simplyhired` | WIP | Cheerio + Playwright fallback; TODO: validate against anti-bot measures |
+| Wellfound (AngelList) | Job Board | `source-wellfound` | WIP | Playwright SPA; TODO: validate `__NEXT_DATA__` structure |
+| StepStone | Job Board | `source-stepstone` | WIP | Playwright SPA; TODO: validate selectors, currently Germany-only |
+| Comeet | ATS | — | Planned | Deferred to future iteration |
+| Pinpoint | ATS | — | Planned | Deferred to future iteration |
 
-### Tier 3 - Heavy Anti-Bot (Hard)
+### Tier 3 - Heavy Anti-Bot (Phase 4 - Planned)
 
 | Source | Type | Notes |
 |--------|------|-------|
@@ -234,5 +234,5 @@ API Request
 |-------|---------|--------|
 | **Phase 1 (Tier 1)** | RemoteOK, Remotive, Jobicy, Himalayas, Arbeitnow, WeWorkRemotely, Recruitee, Teamtailor | ✅ **Complete** |
 | **Phase 2 (Tier 1.5)** | USAJobs, Adzuna, Reed, Jooble, CareerJet | ✅ **Complete** |
-| **Phase 3 (Tier 2)** | Wellfound, StepStone, Dice, SimplyHired, JazzHR, Personio, BambooHR | Planned |
+| **Phase 3 (Tier 2)** | BambooHR ✅, Personio ✅, JazzHR 🚧, Dice 🚧, SimplyHired 🚧, Wellfound 🚧, StepStone 🚧 | 🚧 **In Progress** (2/7 complete, 5 WIP) |
 | **Phase 4 (Tier 3)** | Monster, CareerBuilder, iCIMS, Taleo, SuccessFactors | Planned |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,8 +1,8 @@
 # Roadmap
 
-## Current (v0.2.x)
+## Current (v0.3.x)
 
-- ✅ Multi-source job searching (39 sources)
+- ✅ Multi-source job searching (46 sources)
 - ✅ API key authentication
 - ✅ Rate limiting
 - ✅ In-memory caching
@@ -11,13 +11,14 @@
 - ✅ Docker deployment
 - ✅ Swagger / OpenAPI docs
 - ✅ CLI application
-- ✅ ATS integrations (Ashby, Greenhouse, Lever, Workable, SmartRecruiters, Rippling, Workday, Recruitee, Teamtailor)
+- ✅ ATS integrations (Ashby, Greenhouse, Lever, Workable, SmartRecruiters, Rippling, Workday, Recruitee, Teamtailor, BambooHR, Personio, JazzHR)
 - ✅ Company-specific scrapers (Amazon, Apple, Microsoft, Nvidia, TikTok, Uber, Cursor)
 - ✅ Remote job boards (RemoteOK, Remotive, Jobicy, Himalayas, Arbeitnow, We Work Remotely)
 - ✅ API-key sources (USAJobs, Adzuna, Reed, Jooble, CareerJet — Tier 1.5)
 - ✅ Client IP forwarding for proxy rotation strategies
+- 🚧 Tier 2 HTML scrapers — BambooHR ✅, Personio ✅, JazzHR 🚧, Dice 🚧, SimplyHired 🚧, Wellfound 🚧, StepStone 🚧
 
-## Planned (v0.3.0)
+## Planned (v0.4.0)
 
 - Redis-backed caching (scalable, persistent)
 - WebSocket / SSE support for real-time search progress
@@ -25,9 +26,8 @@
 - Configurable retry policies per source
 - Prometheus metrics endpoint (`/metrics`)
 
-## Future Considerations (v0.4.0+)
+## Future Considerations (v0.5.0+)
 
-- Tier 2 sources: Wellfound (AngelList), StepStone, Dice, SimplyHired, JazzHR, Personio, BambooHR
 - Tier 3 sources: Monster, CareerBuilder, iCIMS, Oracle Taleo, SAP SuccessFactors
 - GraphQL API alongside REST
 - OAuth2 authentication

--- a/packages/models/src/enums/site.enum.ts
+++ b/packages/models/src/enums/site.enum.ts
@@ -37,6 +37,13 @@ export enum Site {
   REED = 'reed',
   JOOBLE = 'jooble',
   CAREERJET = 'careerjet',
+  BAMBOOHR = 'bamboohr',
+  PERSONIO = 'personio',
+  JAZZHR = 'jazzhr',
+  DICE = 'dice',
+  SIMPLYHIRED = 'simplyhired',
+  WELLFOUND = 'wellfound',
+  STEPSTONE = 'stepstone',
 }
 
 /**

--- a/packages/source-ats-bamboohr/package.json
+++ b/packages/source-ats-bamboohr/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@ever-jobs/source-ats-bamboohr",
+  "version": "0.1.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "MIT"
+}

--- a/packages/source-ats-bamboohr/src/bamboohr.constants.ts
+++ b/packages/source-ats-bamboohr/src/bamboohr.constants.ts
@@ -1,0 +1,9 @@
+/** BambooHR public careers list endpoint (slug interpolated at runtime) */
+export const BAMBOOHR_CAREERS_URL = 'https://{slug}.bamboohr.com/careers/list';
+
+/** Default headers for BambooHR careers requests */
+export const BAMBOOHR_HEADERS: Record<string, string> = {
+  Accept: 'application/json',
+  'User-Agent':
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129 Safari/537.36',
+};

--- a/packages/source-ats-bamboohr/src/bamboohr.module.ts
+++ b/packages/source-ats-bamboohr/src/bamboohr.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { BambooHRService } from './bamboohr.service';
+
+@Module({
+  providers: [BambooHRService],
+  exports: [BambooHRService],
+})
+export class BambooHRModule {}

--- a/packages/source-ats-bamboohr/src/bamboohr.service.ts
+++ b/packages/source-ats-bamboohr/src/bamboohr.service.ts
@@ -1,0 +1,116 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  IScraper,
+  ScraperInputDto,
+  JobResponseDto,
+  JobPostDto,
+  LocationDto,
+  Site,
+  DescriptionFormat,
+} from '@ever-jobs/models';
+import {
+  createHttpClient,
+  htmlToPlainText,
+  markdownConverter,
+  extractEmails,
+} from '@ever-jobs/common';
+import { BAMBOOHR_HEADERS } from './bamboohr.constants';
+import { BambooHRResponse, BambooHRJob } from './bamboohr.types';
+
+@Injectable()
+export class BambooHRService implements IScraper {
+  private readonly logger = new Logger(BambooHRService.name);
+
+  async scrape(input: ScraperInputDto): Promise<JobResponseDto> {
+    const companySlug = input.companySlug;
+    if (!companySlug) {
+      this.logger.warn('No companySlug provided for BambooHR scraper');
+      return new JobResponseDto([]);
+    }
+
+    const client = createHttpClient({
+      proxies: input.proxies,
+      caCert: input.caCert,
+      timeout: input.requestTimeout,
+    });
+    client.setHeaders(BAMBOOHR_HEADERS);
+
+    const url = `https://${encodeURIComponent(companySlug)}.bamboohr.com/careers/list`;
+
+    try {
+      this.logger.log(`Fetching BambooHR jobs for company: ${companySlug}`);
+      const response = await client.get(url);
+      const data: BambooHRResponse = response.data ?? { result: [] };
+      const jobs = data.result ?? [];
+
+      this.logger.log(`BambooHR: found ${jobs.length} raw jobs for ${companySlug}`);
+
+      const resultsWanted = input.resultsWanted ?? 100;
+      const jobPosts: JobPostDto[] = [];
+
+      for (const job of jobs) {
+        if (jobPosts.length >= resultsWanted) break;
+
+        try {
+          const post = this.mapJob(job, companySlug, input.descriptionFormat);
+          if (post) {
+            jobPosts.push(post);
+          }
+        } catch (err: any) {
+          this.logger.warn(`Error processing BambooHR job ${job.id}: ${err.message}`);
+        }
+      }
+
+      return new JobResponseDto(jobPosts);
+    } catch (err: any) {
+      this.logger.error(`BambooHR scrape error for ${companySlug}: ${err.message}`);
+      return new JobResponseDto([]);
+    }
+  }
+
+  private mapJob(
+    job: BambooHRJob,
+    companySlug: string,
+    format?: DescriptionFormat,
+  ): JobPostDto | null {
+    const title = job.jobOpeningName;
+    if (!title) return null;
+
+    // Description is HTML
+    let description: string | null = null;
+    if (job.description) {
+      if (format === DescriptionFormat.HTML) {
+        description = job.description;
+      } else if (format === DescriptionFormat.MARKDOWN) {
+        description = markdownConverter(job.description) ?? job.description;
+      } else {
+        description = htmlToPlainText(job.description);
+      }
+    }
+
+    // Location
+    const location = new LocationDto({
+      city: job.location?.city ?? null,
+      state: job.location?.state ?? null,
+      country: job.location?.country ?? null,
+    });
+
+    // Job URL
+    const jobUrl = `https://${encodeURIComponent(companySlug)}.bamboohr.com/careers/${job.id}`;
+
+    return new JobPostDto({
+      id: `bamboohr-${job.id}`,
+      title,
+      companyName: companySlug,
+      jobUrl,
+      location,
+      description,
+      isRemote: false,
+      emails: extractEmails(description),
+      site: Site.BAMBOOHR,
+      atsId: String(job.id),
+      atsType: 'bamboohr',
+      department: job.departmentLabel ?? null,
+    });
+  }
+}

--- a/packages/source-ats-bamboohr/src/bamboohr.types.ts
+++ b/packages/source-ats-bamboohr/src/bamboohr.types.ts
@@ -1,0 +1,22 @@
+/**
+ * TypeScript interfaces for BambooHR public careers API responses.
+ */
+
+export interface BambooHRResponse {
+  result: BambooHRJob[];
+}
+
+export interface BambooHRJob {
+  id: number;
+  jobOpeningName: string;
+  departmentLabel: string | null;
+  location: {
+    city: string | null;
+    state: string | null;
+    country: string | null;
+  } | null;
+  employmentStatusLabel: string | null;
+  minimumExperience: string | null;
+  compensation: string | null;
+  description: string | null;
+}

--- a/packages/source-ats-bamboohr/src/index.ts
+++ b/packages/source-ats-bamboohr/src/index.ts
@@ -1,0 +1,2 @@
+export { BambooHRModule } from './bamboohr.module';
+export { BambooHRService } from './bamboohr.service';

--- a/packages/source-ats-bamboohr/tsconfig.json
+++ b/packages/source-ats-bamboohr/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../dist/packages/source-ats-bamboohr",
+    "declaration": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/source-ats-jazzhr/package.json
+++ b/packages/source-ats-jazzhr/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@ever-jobs/source-ats-jazzhr",
+  "version": "0.1.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "MIT"
+}

--- a/packages/source-ats-jazzhr/src/index.ts
+++ b/packages/source-ats-jazzhr/src/index.ts
@@ -1,0 +1,2 @@
+export { JazzHRModule } from './jazzhr.module';
+export { JazzHRService } from './jazzhr.service';

--- a/packages/source-ats-jazzhr/src/jazzhr.constants.ts
+++ b/packages/source-ats-jazzhr/src/jazzhr.constants.ts
@@ -1,0 +1,9 @@
+/** JazzHR public career page URL (slug interpolated at runtime) */
+export const JAZZHR_CAREERS_URL = 'https://{slug}.applytojob.com/apply/jobs/';
+
+/** Default headers for JazzHR career page requests */
+export const JAZZHR_HEADERS: Record<string, string> = {
+  Accept: 'text/html',
+  'User-Agent':
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129 Safari/537.36',
+};

--- a/packages/source-ats-jazzhr/src/jazzhr.module.ts
+++ b/packages/source-ats-jazzhr/src/jazzhr.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { JazzHRService } from './jazzhr.service';
+
+@Module({
+  providers: [JazzHRService],
+  exports: [JazzHRService],
+})
+export class JazzHRModule {}

--- a/packages/source-ats-jazzhr/src/jazzhr.service.ts
+++ b/packages/source-ats-jazzhr/src/jazzhr.service.ts
@@ -1,0 +1,150 @@
+// WIP: This source may need selector updates after live testing.
+// JazzHR career pages use different themes so selectors may vary per company.
+import { Injectable, Logger } from '@nestjs/common';
+import * as cheerio from 'cheerio';
+import {
+  IScraper,
+  ScraperInputDto,
+  JobResponseDto,
+  JobPostDto,
+  LocationDto,
+  Site,
+} from '@ever-jobs/models';
+import { createHttpClient } from '@ever-jobs/common';
+import { JAZZHR_HEADERS } from './jazzhr.constants';
+
+@Injectable()
+export class JazzHRService implements IScraper {
+  private readonly logger = new Logger(JazzHRService.name);
+
+  async scrape(input: ScraperInputDto): Promise<JobResponseDto> {
+    const companySlug = input.companySlug;
+    if (!companySlug) {
+      this.logger.warn('No companySlug provided for JazzHR scraper');
+      return new JobResponseDto([]);
+    }
+
+    const client = createHttpClient({
+      proxies: input.proxies,
+      caCert: input.caCert,
+      timeout: input.requestTimeout,
+    });
+    client.setHeaders(JAZZHR_HEADERS);
+
+    const url = `https://${encodeURIComponent(companySlug)}.applytojob.com/apply/jobs/`;
+
+    try {
+      this.logger.log(`Fetching JazzHR career page for company: ${companySlug}`);
+      const response = await client.get<string>(url);
+      const html = response.data;
+
+      if (!html) {
+        this.logger.warn(`JazzHR: empty response for ${companySlug}`);
+        return new JobResponseDto([]);
+      }
+
+      const jobs = this.parseHtml(html, companySlug);
+
+      if (jobs.length === 0) {
+        // TODO: Validate selectors against live JazzHR career pages
+        this.logger.warn(
+          `JazzHR: zero jobs extracted for ${companySlug} — selectors may need updating`,
+        );
+      }
+
+      this.logger.log(`JazzHR: found ${jobs.length} jobs for ${companySlug}`);
+
+      const resultsWanted = input.resultsWanted ?? 100;
+      return new JobResponseDto(jobs.slice(0, resultsWanted));
+    } catch (err: any) {
+      this.logger.error(`JazzHR scrape error for ${companySlug}: ${err.message}`);
+      return new JobResponseDto([]);
+    }
+  }
+
+  private parseHtml(html: string, companySlug: string): JobPostDto[] {
+    const $ = cheerio.load(html);
+    const jobs: JobPostDto[] = [];
+
+    // TODO: Validate selectors against live site — JazzHR themes vary
+    // Common patterns: <a> links inside job listing containers
+    // Selector strategy: try multiple known JazzHR DOM structures
+    const selectors = [
+      'li.list-group-item a[href*="/apply/"]',
+      'div.job-listing a[href*="/apply/"]',
+      'a.job-title[href*="/apply/"]',
+      '.resumator-jobs-list a[href*="/apply/"]',
+      'table.resumator-jobs-table tr a',
+    ];
+
+    let links: cheerio.Cheerio<any> | null = null;
+    for (const sel of selectors) {
+      const found = $(sel);
+      if (found.length > 0) {
+        links = found;
+        break;
+      }
+    }
+
+    // Fallback: find any link that looks like a JazzHR job link
+    if (!links || links.length === 0) {
+      links = $('a[href*="/apply/"]').filter((_, el) => {
+        const href = $(el).attr('href') ?? '';
+        return href.includes('/apply/') && !href.endsWith('/apply/jobs/');
+      });
+    }
+
+    if (!links || links.length === 0) {
+      return [];
+    }
+
+    links.each((_, el) => {
+      try {
+        const a = $(el);
+        const title = a.text().trim();
+        if (!title) return;
+
+        let href = a.attr('href') ?? '';
+        if (!href) return;
+
+        // Make URL absolute if relative
+        if (href.startsWith('/')) {
+          href = `https://${encodeURIComponent(companySlug)}.applytojob.com${href}`;
+        }
+
+        // Try to extract location from sibling/parent elements
+        const parent = a.closest('li, tr, div.job-listing');
+        const locationText = parent.find('.location, .job-location, td:nth-child(2)').text().trim() || null;
+        const deptText = parent.find('.department, .job-department, td:nth-child(3)').text().trim() || null;
+
+        const jobId = `jazzhr-${Math.abs(this.hashCode(href))}`;
+
+        jobs.push(new JobPostDto({
+          id: jobId,
+          title,
+          companyName: companySlug,
+          jobUrl: href,
+          location: locationText ? new LocationDto({ city: locationText }) : null,
+          site: Site.JAZZHR,
+          atsId: jobId,
+          atsType: 'jazzhr',
+          department: deptText,
+        }));
+      } catch (err: any) {
+        this.logger.debug(`JazzHR: failed to parse job card: ${err.message}`);
+      }
+    });
+
+    return jobs;
+  }
+
+  private hashCode(str: string): number {
+    let hash = 0;
+    for (let i = 0; i < str.length; i++) {
+      const char = str.charCodeAt(i);
+      hash = (hash << 5) - hash + char;
+      hash |= 0;
+    }
+    return hash;
+  }
+}

--- a/packages/source-ats-jazzhr/src/jazzhr.types.ts
+++ b/packages/source-ats-jazzhr/src/jazzhr.types.ts
@@ -1,0 +1,11 @@
+/**
+ * TypeScript interfaces for JazzHR career page job listings.
+ * Parsed from HTML via cheerio.
+ */
+
+export interface JazzHRJobListing {
+  title: string;
+  jobUrl: string;
+  location: string | null;
+  department: string | null;
+}

--- a/packages/source-ats-jazzhr/tsconfig.json
+++ b/packages/source-ats-jazzhr/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../dist/packages/source-ats-jazzhr",
+    "declaration": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/source-ats-personio/package.json
+++ b/packages/source-ats-personio/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@ever-jobs/source-ats-personio",
+  "version": "0.1.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "MIT"
+}

--- a/packages/source-ats-personio/src/index.ts
+++ b/packages/source-ats-personio/src/index.ts
@@ -1,0 +1,2 @@
+export { PersonioModule } from './personio.module';
+export { PersonioService } from './personio.service';

--- a/packages/source-ats-personio/src/personio.constants.ts
+++ b/packages/source-ats-personio/src/personio.constants.ts
@@ -1,0 +1,14 @@
+/** Personio public XML feed URL patterns (slug interpolated at runtime) */
+export const PERSONIO_XML_URL_DE = 'https://{slug}.jobs.personio.de/xml';
+export const PERSONIO_XML_URL_COM = 'https://{slug}.jobs.personio.com/xml';
+
+/** Base URL for constructing job detail links */
+export const PERSONIO_JOB_URL_DE = 'https://{slug}.jobs.personio.de/job';
+export const PERSONIO_JOB_URL_COM = 'https://{slug}.jobs.personio.com/job';
+
+/** Default headers for Personio XML requests */
+export const PERSONIO_HEADERS: Record<string, string> = {
+  Accept: 'application/xml, text/xml',
+  'User-Agent':
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129 Safari/537.36',
+};

--- a/packages/source-ats-personio/src/personio.module.ts
+++ b/packages/source-ats-personio/src/personio.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { PersonioService } from './personio.service';
+
+@Module({
+  providers: [PersonioService],
+  exports: [PersonioService],
+})
+export class PersonioModule {}

--- a/packages/source-ats-personio/src/personio.service.ts
+++ b/packages/source-ats-personio/src/personio.service.ts
@@ -1,0 +1,191 @@
+import { Injectable, Logger } from '@nestjs/common';
+import * as cheerio from 'cheerio';
+import {
+  IScraper,
+  ScraperInputDto,
+  JobResponseDto,
+  JobPostDto,
+  LocationDto,
+  Site,
+  DescriptionFormat,
+} from '@ever-jobs/models';
+import {
+  createHttpClient,
+  htmlToPlainText,
+  markdownConverter,
+  extractEmails,
+} from '@ever-jobs/common';
+import {
+  PERSONIO_XML_URL_DE,
+  PERSONIO_XML_URL_COM,
+  PERSONIO_JOB_URL_DE,
+  PERSONIO_HEADERS,
+} from './personio.constants';
+import { PersonioPosition, PersonioDescription } from './personio.types';
+
+@Injectable()
+export class PersonioService implements IScraper {
+  private readonly logger = new Logger(PersonioService.name);
+
+  async scrape(input: ScraperInputDto): Promise<JobResponseDto> {
+    const companySlug = input.companySlug;
+    if (!companySlug) {
+      this.logger.warn('No companySlug provided for Personio scraper');
+      return new JobResponseDto([]);
+    }
+
+    const client = createHttpClient({
+      proxies: input.proxies,
+      caCert: input.caCert,
+      timeout: input.requestTimeout,
+    });
+    client.setHeaders(PERSONIO_HEADERS);
+
+    // Try .de domain first, then .com fallback
+    const urlDe = PERSONIO_XML_URL_DE.replace('{slug}', encodeURIComponent(companySlug))
+      + '?language=en';
+    const urlCom = PERSONIO_XML_URL_COM.replace('{slug}', encodeURIComponent(companySlug))
+      + '?language=en';
+
+    let xmlData: string | null = null;
+    let usedDomain: 'de' | 'com' = 'de';
+
+    try {
+      this.logger.log(`Fetching Personio XML feed (.de) for: ${companySlug}`);
+      const response = await client.get<string>(urlDe);
+      xmlData = response.data;
+    } catch {
+      this.logger.log(`Personio .de failed, trying .com for: ${companySlug}`);
+      try {
+        const response = await client.get<string>(urlCom);
+        xmlData = response.data;
+        usedDomain = 'com';
+      } catch (err: any) {
+        this.logger.error(`Personio scrape error for ${companySlug}: ${err.message}`);
+        return new JobResponseDto([]);
+      }
+    }
+
+    if (!xmlData) {
+      return new JobResponseDto([]);
+    }
+
+    try {
+      const positions = this.parseXml(xmlData);
+      this.logger.log(`Personio: found ${positions.length} positions for ${companySlug}`);
+
+      const resultsWanted = input.resultsWanted ?? 100;
+      const jobPosts: JobPostDto[] = [];
+
+      for (const pos of positions) {
+        if (jobPosts.length >= resultsWanted) break;
+
+        try {
+          const post = this.mapPosition(pos, companySlug, usedDomain, input.descriptionFormat);
+          if (post) {
+            jobPosts.push(post);
+          }
+        } catch (err: any) {
+          this.logger.warn(`Error processing Personio position ${pos.id}: ${err.message}`);
+        }
+      }
+
+      return new JobResponseDto(jobPosts);
+    } catch (err: any) {
+      this.logger.error(`Personio XML parse error for ${companySlug}: ${err.message}`);
+      return new JobResponseDto([]);
+    }
+  }
+
+  private parseXml(xml: string): PersonioPosition[] {
+    const $ = cheerio.load(xml, { xmlMode: true });
+    const positions: PersonioPosition[] = [];
+
+    $('position').each((_, el) => {
+      const pos = $(el);
+      const descriptions: PersonioDescription[] = [];
+
+      pos.find('jobDescriptions jobDescription').each((__, descEl) => {
+        const d = $(descEl);
+        descriptions.push({
+          name: d.find('name').text().trim(),
+          value: d.find('value').text().trim(),
+        });
+      });
+
+      positions.push({
+        id: pos.find('id').first().text().trim(),
+        name: pos.find('name').first().text().trim(),
+        office: pos.find('office').text().trim() || null,
+        department: pos.find('department').text().trim() || null,
+        recruitingCategory: pos.find('recruitingCategory').text().trim() || null,
+        employmentType: pos.find('employmentType').text().trim() || null,
+        seniority: pos.find('seniority').text().trim() || null,
+        schedule: pos.find('schedule').text().trim() || null,
+        keywords: pos.find('keywords').text().trim() || null,
+        createdAt: pos.find('createdAt').text().trim() || null,
+        descriptions,
+      });
+    });
+
+    return positions;
+  }
+
+  private mapPosition(
+    pos: PersonioPosition,
+    companySlug: string,
+    domain: 'de' | 'com',
+    format?: DescriptionFormat,
+  ): JobPostDto | null {
+    if (!pos.name || !pos.id) return null;
+
+    // Combine all description sections
+    const rawHtml = pos.descriptions
+      .map((d) => d.value)
+      .filter(Boolean)
+      .join('\n');
+
+    let description: string | null = null;
+    if (rawHtml) {
+      if (format === DescriptionFormat.HTML) {
+        description = rawHtml;
+      } else if (format === DescriptionFormat.MARKDOWN) {
+        description = markdownConverter(rawHtml) ?? rawHtml;
+      } else {
+        description = htmlToPlainText(rawHtml);
+      }
+    }
+
+    const location = new LocationDto({
+      city: pos.office,
+    });
+
+    const tld = domain === 'de' ? 'de' : 'com';
+    const jobUrl = `https://${encodeURIComponent(companySlug)}.jobs.personio.${tld}/job/${pos.id}`;
+
+    const datePosted = pos.createdAt
+      ? new Date(pos.createdAt).toISOString().split('T')[0]
+      : null;
+
+    const skills = pos.keywords
+      ? pos.keywords.split(',').map((s) => s.trim()).filter(Boolean)
+      : null;
+
+    return new JobPostDto({
+      id: `personio-${pos.id}`,
+      title: pos.name,
+      companyName: companySlug,
+      jobUrl,
+      location,
+      description,
+      datePosted,
+      isRemote: false,
+      emails: extractEmails(description),
+      site: Site.PERSONIO,
+      atsId: pos.id,
+      atsType: 'personio',
+      department: pos.department,
+      skills,
+    });
+  }
+}

--- a/packages/source-ats-personio/src/personio.types.ts
+++ b/packages/source-ats-personio/src/personio.types.ts
@@ -1,0 +1,23 @@
+/**
+ * TypeScript interfaces for Personio XML feed positions.
+ * The XML is parsed into these structures via cheerio xmlMode.
+ */
+
+export interface PersonioPosition {
+  id: string;
+  name: string;
+  office: string | null;
+  department: string | null;
+  recruitingCategory: string | null;
+  employmentType: string | null;
+  seniority: string | null;
+  schedule: string | null;
+  keywords: string | null;
+  createdAt: string | null;
+  descriptions: PersonioDescription[];
+}
+
+export interface PersonioDescription {
+  name: string;
+  value: string;
+}

--- a/packages/source-ats-personio/tsconfig.json
+++ b/packages/source-ats-personio/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../dist/packages/source-ats-personio",
+    "declaration": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/source-dice/package.json
+++ b/packages/source-dice/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@ever-jobs/source-dice",
+  "version": "0.1.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "MIT"
+}

--- a/packages/source-dice/src/dice.constants.ts
+++ b/packages/source-dice/src/dice.constants.ts
@@ -1,0 +1,17 @@
+/** Dice search URL */
+export const DICE_SEARCH_URL = 'https://www.dice.com/jobs';
+
+/** Default delay between page requests (ms) */
+export const DICE_DELAY_MIN = 3000;
+export const DICE_DELAY_MAX = 6000;
+
+/** Default headers for Dice requests */
+export const DICE_HEADERS: Record<string, string> = {
+  Accept: 'text/html,application/xhtml+xml',
+  'Accept-Language': 'en-US,en;q=0.9',
+  'User-Agent':
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+};
+
+/** Page size per request */
+export const DICE_PAGE_SIZE = 20;

--- a/packages/source-dice/src/dice.module.ts
+++ b/packages/source-dice/src/dice.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { DiceService } from './dice.service';
+
+@Module({
+  providers: [DiceService],
+  exports: [DiceService],
+})
+export class DiceModule {}

--- a/packages/source-dice/src/dice.service.ts
+++ b/packages/source-dice/src/dice.service.ts
@@ -1,0 +1,249 @@
+// WIP: This source may need selector updates after live testing.
+// Dice is a React SPA — cheerio may fail and Playwright is the primary fallback.
+import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
+import * as cheerio from 'cheerio';
+import {
+  IScraper,
+  ScraperInputDto,
+  JobResponseDto,
+  JobPostDto,
+  LocationDto,
+  Site,
+} from '@ever-jobs/models';
+import {
+  createHttpClient,
+  randomSleep,
+  extractSalary,
+  extractEmails,
+} from '@ever-jobs/common';
+import { BrowserPool } from '@ever-jobs/common';
+import {
+  DICE_SEARCH_URL,
+  DICE_HEADERS,
+  DICE_DELAY_MIN,
+  DICE_DELAY_MAX,
+  DICE_PAGE_SIZE,
+} from './dice.constants';
+
+@Injectable()
+export class DiceService implements IScraper, OnModuleDestroy {
+  private readonly logger = new Logger(DiceService.name);
+
+  async scrape(input: ScraperInputDto): Promise<JobResponseDto> {
+    const resultsWanted = input.resultsWanted ?? 15;
+
+    // Try cheerio-based scraping first
+    const cheerioJobs = await this.scrapeWithCheerio(input, resultsWanted);
+    if (cheerioJobs.length > 0) {
+      return new JobResponseDto(cheerioJobs);
+    }
+
+    // Fallback to Playwright if cheerio returned nothing
+    this.logger.log('Dice: cheerio returned zero results, falling back to Playwright');
+    const playwrightJobs = await this.scrapeWithPlaywright(input, resultsWanted);
+    return new JobResponseDto(playwrightJobs);
+  }
+
+  private async scrapeWithCheerio(
+    input: ScraperInputDto,
+    resultsWanted: number,
+  ): Promise<JobPostDto[]> {
+    const client = createHttpClient({
+      proxies: input.proxies,
+      caCert: input.caCert,
+      timeout: input.requestTimeout,
+    });
+    client.setHeaders(DICE_HEADERS);
+
+    const allJobs: JobPostDto[] = [];
+    let page = 1;
+    const maxPages = Math.ceil(resultsWanted / DICE_PAGE_SIZE) + 1;
+
+    while (allJobs.length < resultsWanted && page <= maxPages) {
+      try {
+        const url = new URL(DICE_SEARCH_URL);
+        if (input.searchTerm) url.searchParams.set('q', input.searchTerm);
+        if (input.location) url.searchParams.set('location', input.location);
+        url.searchParams.set('page', String(page));
+        url.searchParams.set('pageSize', String(DICE_PAGE_SIZE));
+        url.searchParams.set('countryCode', 'US');
+        url.searchParams.set('language', 'en');
+
+        this.logger.log(`Fetching Dice search page ${page}`);
+        const response = await client.get<string>(url.toString());
+        const html = response.data;
+
+        const jobs = this.parseHtml(html);
+        if (jobs.length === 0) break;
+
+        allJobs.push(...jobs);
+        page++;
+
+        if (page <= maxPages && allJobs.length < resultsWanted) {
+          await randomSleep(DICE_DELAY_MIN, DICE_DELAY_MAX);
+        }
+      } catch (err: any) {
+        this.logger.error(`Dice cheerio scrape error page ${page}: ${err.message}`);
+        break;
+      }
+    }
+
+    return allJobs.slice(0, resultsWanted);
+  }
+
+  private async scrapeWithPlaywright(
+    input: ScraperInputDto,
+    resultsWanted: number,
+  ): Promise<JobPostDto[]> {
+    const proxy = input.proxies?.[0] ?? undefined;
+    let page;
+
+    try {
+      page = await BrowserPool.getPage({ proxy });
+      const timeoutMs = (input.requestTimeout ?? 30) * 1000;
+
+      const url = new URL(DICE_SEARCH_URL);
+      if (input.searchTerm) url.searchParams.set('q', input.searchTerm);
+      if (input.location) url.searchParams.set('location', input.location);
+      url.searchParams.set('countryCode', 'US');
+      url.searchParams.set('language', 'en');
+
+      this.logger.log(`Dice Playwright: navigating to ${url.toString()}`);
+      await page.goto(url.toString(), {
+        waitUntil: 'domcontentloaded',
+        timeout: timeoutMs,
+      });
+
+      // Wait for JS hydration
+      await this.delay(5000);
+
+      const html = await page.content();
+      const jobs = this.parseHtml(html);
+
+      if (jobs.length === 0) {
+        // TODO: Validate selectors against live Dice rendered DOM
+        this.logger.warn('Dice Playwright: zero jobs extracted — selectors may need updating');
+      }
+
+      this.logger.log(`Dice Playwright: extracted ${jobs.length} jobs`);
+      return jobs.slice(0, resultsWanted);
+    } catch (err: any) {
+      this.logger.error(`Dice Playwright scrape failed: ${err.message}`);
+      return [];
+    } finally {
+      if (page) {
+        const context = page.context();
+        await page.close().catch(() => {});
+        await context.close().catch(() => {});
+      }
+    }
+  }
+
+  private parseHtml(html: string): JobPostDto[] {
+    const $ = cheerio.load(html);
+    const jobs: JobPostDto[] = [];
+
+    // TODO: Validate selectors against live Dice pages
+    // Dice job cards are typically rendered with data attributes or search card classes
+    const selectors = [
+      '[data-cy="search-card"]',
+      'dhi-search-card',
+      '.search-card',
+      'a[data-id]',
+    ];
+
+    let cards: cheerio.Cheerio<any> | null = null;
+    for (const sel of selectors) {
+      const found = $(sel);
+      if (found.length > 0) {
+        cards = found;
+        break;
+      }
+    }
+
+    if (!cards || cards.length === 0) {
+      return [];
+    }
+
+    cards.each((_, el) => {
+      try {
+        const card = $(el);
+
+        // Extract title from link or heading
+        const titleEl = card.find('a.card-title-link, h5 a, [data-cy="card-title"]').first();
+        const title = titleEl.text().trim() ||
+          card.find('a').first().text().trim();
+        if (!title) return;
+
+        // Extract URL
+        let href = titleEl.attr('href') ?? card.find('a').first().attr('href') ?? '';
+        if (href && !href.startsWith('http')) {
+          href = `https://www.dice.com${href}`;
+        }
+        if (!href) return;
+
+        // Extract company
+        const company = card.find('[data-cy="search-result-company-name"], .card-company').text().trim() || null;
+
+        // Extract location
+        const location = card.find('[data-cy="search-result-location"], .card-location').text().trim() || null;
+
+        // Extract salary
+        const salaryText = card.find('[data-cy="search-result-salary"], .card-salary').text().trim() || null;
+        let compensation = null;
+        if (salaryText) {
+          const parsed = extractSalary(salaryText);
+          if (parsed.minAmount != null) {
+            compensation = {
+              interval: parsed.interval,
+              minAmount: parsed.minAmount,
+              maxAmount: parsed.maxAmount,
+              currency: parsed.currency ?? 'USD',
+            };
+          }
+        }
+
+        // Extract posted date
+        const dateText = card.find('[data-cy="card-posted-date"], .card-posted-date').text().trim() || null;
+
+        // Generate unique ID from URL
+        const idMatch = href.match(/\/job-detail\/([^/?]+)/);
+        const id = idMatch ? `dice-${idMatch[1]}` : `dice-${Math.abs(this.hashCode(href))}`;
+
+        jobs.push(new JobPostDto({
+          id,
+          title,
+          companyName: company,
+          jobUrl: href,
+          location: location ? new LocationDto({ city: location }) : null,
+          compensation: compensation as any,
+          datePosted: dateText,
+          emails: null,
+          site: Site.DICE,
+        }));
+      } catch (err: any) {
+        // Skip individual card parse errors
+      }
+    });
+
+    return jobs;
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await BrowserPool.close();
+  }
+
+  private delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  private hashCode(str: string): number {
+    let hash = 0;
+    for (let i = 0; i < str.length; i++) {
+      const char = str.charCodeAt(i);
+      hash = (hash << 5) - hash + char;
+      hash |= 0;
+    }
+    return hash;
+  }
+}

--- a/packages/source-dice/src/dice.types.ts
+++ b/packages/source-dice/src/dice.types.ts
@@ -1,0 +1,13 @@
+/**
+ * TypeScript interfaces for Dice job cards parsed from HTML.
+ */
+
+export interface DiceJobCard {
+  title: string;
+  url: string;
+  company: string | null;
+  location: string | null;
+  salary: string | null;
+  postedDate: string | null;
+  employmentType: string | null;
+}

--- a/packages/source-dice/src/index.ts
+++ b/packages/source-dice/src/index.ts
@@ -1,0 +1,2 @@
+export { DiceModule } from './dice.module';
+export { DiceService } from './dice.service';

--- a/packages/source-dice/tsconfig.json
+++ b/packages/source-dice/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../dist/packages/source-dice",
+    "declaration": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/source-simplyhired/package.json
+++ b/packages/source-simplyhired/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@ever-jobs/source-simplyhired",
+  "version": "0.1.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "MIT"
+}

--- a/packages/source-simplyhired/src/index.ts
+++ b/packages/source-simplyhired/src/index.ts
@@ -1,0 +1,2 @@
+export { SimplyHiredModule } from './simplyhired.module';
+export { SimplyHiredService } from './simplyhired.service';

--- a/packages/source-simplyhired/src/simplyhired.constants.ts
+++ b/packages/source-simplyhired/src/simplyhired.constants.ts
@@ -1,0 +1,14 @@
+/** SimplyHired search URL */
+export const SIMPLYHIRED_SEARCH_URL = 'https://www.simplyhired.com/search';
+
+/** Default delay between page requests (ms) */
+export const SIMPLYHIRED_DELAY_MIN = 2000;
+export const SIMPLYHIRED_DELAY_MAX = 5000;
+
+/** Default headers for SimplyHired requests */
+export const SIMPLYHIRED_HEADERS: Record<string, string> = {
+  Accept: 'text/html,application/xhtml+xml',
+  'Accept-Language': 'en-US,en;q=0.9',
+  'User-Agent':
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+};

--- a/packages/source-simplyhired/src/simplyhired.module.ts
+++ b/packages/source-simplyhired/src/simplyhired.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { SimplyHiredService } from './simplyhired.service';
+
+@Module({
+  providers: [SimplyHiredService],
+  exports: [SimplyHiredService],
+})
+export class SimplyHiredModule {}

--- a/packages/source-simplyhired/src/simplyhired.service.ts
+++ b/packages/source-simplyhired/src/simplyhired.service.ts
@@ -1,0 +1,234 @@
+// WIP: This source may need selector updates after live testing.
+// SimplyHired is owned by Indeed and may have anti-bot measures.
+import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
+import * as cheerio from 'cheerio';
+import {
+  IScraper,
+  ScraperInputDto,
+  JobResponseDto,
+  JobPostDto,
+  LocationDto,
+  Site,
+} from '@ever-jobs/models';
+import {
+  createHttpClient,
+  randomSleep,
+  extractSalary,
+} from '@ever-jobs/common';
+import { BrowserPool } from '@ever-jobs/common';
+import {
+  SIMPLYHIRED_SEARCH_URL,
+  SIMPLYHIRED_HEADERS,
+  SIMPLYHIRED_DELAY_MIN,
+  SIMPLYHIRED_DELAY_MAX,
+} from './simplyhired.constants';
+
+@Injectable()
+export class SimplyHiredService implements IScraper, OnModuleDestroy {
+  private readonly logger = new Logger(SimplyHiredService.name);
+
+  async scrape(input: ScraperInputDto): Promise<JobResponseDto> {
+    const resultsWanted = input.resultsWanted ?? 15;
+
+    // Try cheerio first
+    const cheerioJobs = await this.scrapeWithCheerio(input, resultsWanted);
+    if (cheerioJobs.length > 0) {
+      return new JobResponseDto(cheerioJobs);
+    }
+
+    // Fallback to Playwright if cheerio failed (likely anti-bot block)
+    this.logger.log('SimplyHired: cheerio returned zero results, falling back to Playwright');
+    const playwrightJobs = await this.scrapeWithPlaywright(input, resultsWanted);
+    return new JobResponseDto(playwrightJobs);
+  }
+
+  private async scrapeWithCheerio(
+    input: ScraperInputDto,
+    resultsWanted: number,
+  ): Promise<JobPostDto[]> {
+    const client = createHttpClient({
+      proxies: input.proxies,
+      caCert: input.caCert,
+      timeout: input.requestTimeout,
+    });
+    client.setHeaders(SIMPLYHIRED_HEADERS);
+
+    const allJobs: JobPostDto[] = [];
+    let page = 1;
+    const maxPages = Math.ceil(resultsWanted / 20) + 1;
+
+    while (allJobs.length < resultsWanted && page <= maxPages) {
+      try {
+        const url = new URL(SIMPLYHIRED_SEARCH_URL);
+        if (input.searchTerm) url.searchParams.set('q', input.searchTerm);
+        if (input.location) url.searchParams.set('l', input.location);
+        if (page > 1) url.searchParams.set('pn', String(page));
+
+        this.logger.log(`Fetching SimplyHired search page ${page}`);
+        const response = await client.get<string>(url.toString());
+        const html = response.data;
+
+        const jobs = this.parseHtml(html);
+        if (jobs.length === 0) break;
+
+        allJobs.push(...jobs);
+        page++;
+
+        if (page <= maxPages && allJobs.length < resultsWanted) {
+          await randomSleep(SIMPLYHIRED_DELAY_MIN, SIMPLYHIRED_DELAY_MAX);
+        }
+      } catch (err: any) {
+        this.logger.error(`SimplyHired cheerio error page ${page}: ${err.message}`);
+        break;
+      }
+    }
+
+    return allJobs.slice(0, resultsWanted);
+  }
+
+  private async scrapeWithPlaywright(
+    input: ScraperInputDto,
+    resultsWanted: number,
+  ): Promise<JobPostDto[]> {
+    const proxy = input.proxies?.[0] ?? undefined;
+    let page;
+
+    try {
+      page = await BrowserPool.getPage({ proxy });
+      const timeoutMs = (input.requestTimeout ?? 30) * 1000;
+
+      const url = new URL(SIMPLYHIRED_SEARCH_URL);
+      if (input.searchTerm) url.searchParams.set('q', input.searchTerm);
+      if (input.location) url.searchParams.set('l', input.location);
+
+      this.logger.log(`SimplyHired Playwright: navigating to ${url.toString()}`);
+      await page.goto(url.toString(), {
+        waitUntil: 'domcontentloaded',
+        timeout: timeoutMs,
+      });
+
+      await this.delay(5000);
+
+      const html = await page.content();
+      const jobs = this.parseHtml(html);
+
+      if (jobs.length === 0) {
+        // TODO: Validate selectors against live SimplyHired rendered DOM
+        this.logger.warn('SimplyHired Playwright: zero jobs extracted — selectors may need updating');
+      }
+
+      this.logger.log(`SimplyHired Playwright: extracted ${jobs.length} jobs`);
+      return jobs.slice(0, resultsWanted);
+    } catch (err: any) {
+      this.logger.error(`SimplyHired Playwright scrape failed: ${err.message}`);
+      return [];
+    } finally {
+      if (page) {
+        const context = page.context();
+        await page.close().catch(() => {});
+        await context.close().catch(() => {});
+      }
+    }
+  }
+
+  private parseHtml(html: string): JobPostDto[] {
+    const $ = cheerio.load(html);
+    const jobs: JobPostDto[] = [];
+
+    // TODO: Validate selectors against live site
+    const selectors = [
+      '[data-testid="searchSerpJob"]',
+      '.SerpJob',
+      'article.SerpJob-jobCard',
+      'li[data-jobkey]',
+      '.jobposting-subtitle',
+    ];
+
+    let cards: cheerio.Cheerio<any> | null = null;
+    for (const sel of selectors) {
+      const found = $(sel);
+      if (found.length > 0) {
+        cards = found;
+        break;
+      }
+    }
+
+    // Broader fallback
+    if (!cards || cards.length === 0) {
+      cards = $('article, [data-job-id]');
+    }
+
+    if (!cards || cards.length === 0) {
+      return [];
+    }
+
+    cards.each((_, el) => {
+      try {
+        const card = $(el);
+
+        const titleEl = card.find('h2 a, h3 a, .jobposting-title a, a[data-testid="searchSerpJobTitle"]').first();
+        const title = titleEl.text().trim();
+        if (!title) return;
+
+        let href = titleEl.attr('href') ?? '';
+        if (!href) return;
+        if (href.startsWith('/')) {
+          href = `https://www.simplyhired.com${href}`;
+        }
+
+        const company = card.find('[data-testid="companyName"], .jobposting-company, .SerpJob-link--company').text().trim() || null;
+        const location = card.find('[data-testid="searchSerpJobLocation"], .jobposting-location, .SerpJob-location').text().trim() || null;
+        const salaryText = card.find('[data-testid="searchSerpJobSalaryEst"], .jobposting-salary, .SerpJob-salary').text().trim() || null;
+        const snippet = card.find('.jobposting-snippet, .SerpJob-snippet, p').first().text().trim() || null;
+
+        let compensation = null;
+        if (salaryText) {
+          const parsed = extractSalary(salaryText);
+          if (parsed.minAmount != null) {
+            compensation = {
+              interval: parsed.interval,
+              minAmount: parsed.minAmount,
+              maxAmount: parsed.maxAmount,
+              currency: parsed.currency ?? 'USD',
+            };
+          }
+        }
+
+        const id = `simplyhired-${Math.abs(this.hashCode(href))}`;
+
+        jobs.push(new JobPostDto({
+          id,
+          title,
+          companyName: company,
+          jobUrl: href,
+          location: location ? new LocationDto({ city: location }) : null,
+          description: snippet,
+          compensation: compensation as any,
+          site: Site.SIMPLYHIRED,
+        }));
+      } catch {
+        // Skip card errors
+      }
+    });
+
+    return jobs;
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await BrowserPool.close();
+  }
+
+  private delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  private hashCode(str: string): number {
+    let hash = 0;
+    for (let i = 0; i < str.length; i++) {
+      const char = str.charCodeAt(i);
+      hash = (hash << 5) - hash + char;
+      hash |= 0;
+    }
+    return hash;
+  }
+}

--- a/packages/source-simplyhired/src/simplyhired.types.ts
+++ b/packages/source-simplyhired/src/simplyhired.types.ts
@@ -1,0 +1,13 @@
+/**
+ * TypeScript interfaces for SimplyHired job cards parsed from HTML.
+ */
+
+export interface SimplyHiredJobCard {
+  title: string;
+  url: string;
+  company: string | null;
+  location: string | null;
+  salary: string | null;
+  postedDate: string | null;
+  snippet: string | null;
+}

--- a/packages/source-simplyhired/tsconfig.json
+++ b/packages/source-simplyhired/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../dist/packages/source-simplyhired",
+    "declaration": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/source-stepstone/package.json
+++ b/packages/source-stepstone/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@ever-jobs/source-stepstone",
+  "version": "0.1.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "MIT"
+}

--- a/packages/source-stepstone/src/index.ts
+++ b/packages/source-stepstone/src/index.ts
@@ -1,0 +1,2 @@
+export { StepStoneModule } from './stepstone.module';
+export { StepStoneService } from './stepstone.service';

--- a/packages/source-stepstone/src/stepstone.constants.ts
+++ b/packages/source-stepstone/src/stepstone.constants.ts
@@ -1,0 +1,14 @@
+/** StepStone search URL per country */
+export const STEPSTONE_DOMAINS: Record<string, string> = {
+  germany: 'www.stepstone.de',
+  austria: 'www.stepstone.at',
+  belgium: 'www.stepstone.be',
+  netherlands: 'www.stepstone.nl',
+};
+
+/** Default domain (Germany) */
+export const STEPSTONE_DEFAULT_DOMAIN = 'www.stepstone.de';
+
+/** Default delay between page requests (ms) */
+export const STEPSTONE_DELAY_MIN = 3000;
+export const STEPSTONE_DELAY_MAX = 7000;

--- a/packages/source-stepstone/src/stepstone.module.ts
+++ b/packages/source-stepstone/src/stepstone.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { StepStoneService } from './stepstone.service';
+
+@Module({
+  providers: [StepStoneService],
+  exports: [StepStoneService],
+})
+export class StepStoneModule {}

--- a/packages/source-stepstone/src/stepstone.service.ts
+++ b/packages/source-stepstone/src/stepstone.service.ts
@@ -1,0 +1,193 @@
+// WIP: This source may need selector updates after live testing.
+// StepStone is a React SPA with aggressive anti-bot measures.
+// Uses Playwright for rendering. Currently targets Germany (.de) only.
+import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
+import * as cheerio from 'cheerio';
+import {
+  IScraper,
+  ScraperInputDto,
+  JobResponseDto,
+  JobPostDto,
+  LocationDto,
+  CompensationDto,
+  CompensationInterval,
+  Site,
+  DescriptionFormat,
+} from '@ever-jobs/models';
+import {
+  htmlToPlainText,
+  markdownConverter,
+  extractEmails,
+  randomSleep,
+} from '@ever-jobs/common';
+import { BrowserPool } from '@ever-jobs/common';
+import {
+  STEPSTONE_DEFAULT_DOMAIN,
+  STEPSTONE_DELAY_MIN,
+  STEPSTONE_DELAY_MAX,
+} from './stepstone.constants';
+import { StepStoneJsonLd } from './stepstone.types';
+
+@Injectable()
+export class StepStoneService implements IScraper, OnModuleDestroy {
+  private readonly logger = new Logger(StepStoneService.name);
+
+  async scrape(input: ScraperInputDto): Promise<JobResponseDto> {
+    const proxy = input.proxies?.[0] ?? undefined;
+    const resultsWanted = input.resultsWanted ?? 15;
+    // TODO: Support multi-country via input.country mapping
+    const domain = STEPSTONE_DEFAULT_DOMAIN;
+    let page;
+
+    try {
+      page = await BrowserPool.getPage({ proxy });
+      const timeoutMs = (input.requestTimeout ?? 30) * 1000;
+
+      const searchTerm = (input.searchTerm ?? 'developer').replace(/\s+/g, '-');
+      const searchUrl = `https://${domain}/jobs/${encodeURIComponent(searchTerm)}`;
+
+      this.logger.log(`StepStone: navigating to ${searchUrl}`);
+      await page.goto(searchUrl, {
+        waitUntil: 'domcontentloaded',
+        timeout: timeoutMs,
+      });
+
+      // Wait for JS rendering
+      await this.delay(6000);
+
+      const html = await page.content();
+      const jobs = this.parseSearchResults(html, domain);
+
+      if (jobs.length === 0) {
+        // TODO: Validate selectors against live StepStone rendered DOM
+        this.logger.warn(
+          'StepStone: zero jobs extracted — anti-bot may have blocked or selectors need updating',
+        );
+      }
+
+      this.logger.log(`StepStone: extracted ${jobs.length} jobs from search`);
+      return new JobResponseDto(jobs.slice(0, resultsWanted));
+    } catch (err: any) {
+      this.logger.error(`StepStone scrape failed: ${err.message}`);
+      return new JobResponseDto([]);
+    } finally {
+      if (page) {
+        const context = page.context();
+        await page.close().catch(() => {});
+        await context.close().catch(() => {});
+      }
+    }
+  }
+
+  private parseSearchResults(html: string, domain: string): JobPostDto[] {
+    const $ = cheerio.load(html);
+    const jobs: JobPostDto[] = [];
+
+    // TODO: Validate selectors against live StepStone DOM
+    // Try multiple known StepStone search result card patterns
+    const selectors = [
+      'article[data-testid="job-item"]',
+      '[data-at="job-item"]',
+      'article.res-1p3szyi',
+      'div[data-genesis-element="BASE"] article',
+      'a[data-testid="job-item-link"]',
+    ];
+
+    let cards: cheerio.Cheerio<any> | null = null;
+    for (const sel of selectors) {
+      const found = $(sel);
+      if (found.length > 0) {
+        cards = found;
+        break;
+      }
+    }
+
+    // Broader fallback
+    if (!cards || cards.length === 0) {
+      cards = $('article').filter((_, el) => {
+        const links = $(el).find('a[href*="/stellenangebote--"], a[href*="/jobs--"]');
+        return links.length > 0;
+      });
+    }
+
+    if (!cards || cards.length === 0) {
+      return [];
+    }
+
+    cards.each((_, el) => {
+      try {
+        const card = $(el);
+
+        const titleEl = card.find('h2 a, h3 a, [data-at="job-item-title"]').first();
+        const title = titleEl.text().trim() || card.find('a').first().text().trim();
+        if (!title) return;
+
+        let href = titleEl.attr('href') ?? card.find('a').first().attr('href') ?? '';
+        if (!href) return;
+        if (href.startsWith('/')) {
+          href = `https://${domain}${href}`;
+        }
+
+        const company = card.find('[data-at="job-item-company-name"], .res-company-name').text().trim() || null;
+        const location = card.find('[data-at="job-item-location"], .res-location').text().trim() || null;
+
+        const id = `stepstone-${Math.abs(this.hashCode(href))}`;
+
+        jobs.push(new JobPostDto({
+          id,
+          title,
+          companyName: company,
+          jobUrl: href,
+          location: location ? new LocationDto({ city: location }) : null,
+          site: Site.STEPSTONE,
+        }));
+      } catch {
+        // Skip card errors
+      }
+    });
+
+    // Try extracting JSON-LD if present (usually on detail pages, sometimes on search)
+    $('script[type="application/ld+json"]').each((_, el) => {
+      try {
+        const json = JSON.parse($(el).html() ?? '');
+        if (json['@type'] === 'JobPosting') {
+          const ld = json as StepStoneJsonLd;
+          const existing = jobs.find((j) => j.title === ld.title);
+          if (existing && ld.description) {
+            existing.description = htmlToPlainText(ld.description);
+          }
+          if (existing && ld.baseSalary?.value) {
+            existing.compensation = new CompensationDto({
+              interval: CompensationInterval.YEARLY,
+              minAmount: ld.baseSalary.value.minValue ?? undefined,
+              maxAmount: ld.baseSalary.value.maxValue ?? undefined,
+              currency: ld.baseSalary.currency ?? 'EUR',
+            });
+          }
+        }
+      } catch {
+        // Ignore JSON-LD parse errors
+      }
+    });
+
+    return jobs;
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await BrowserPool.close();
+  }
+
+  private delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  private hashCode(str: string): number {
+    let hash = 0;
+    for (let i = 0; i < str.length; i++) {
+      const char = str.charCodeAt(i);
+      hash = (hash << 5) - hash + char;
+      hash |= 0;
+    }
+    return hash;
+  }
+}

--- a/packages/source-stepstone/src/stepstone.types.ts
+++ b/packages/source-stepstone/src/stepstone.types.ts
@@ -1,0 +1,40 @@
+/**
+ * TypeScript interfaces for StepStone job data.
+ *
+ * TODO: Validate against live StepStone rendered DOM
+ */
+
+export interface StepStoneJobCard {
+  title: string;
+  url: string;
+  company: string | null;
+  location: string | null;
+  salary: string | null;
+  postedDate: string | null;
+}
+
+/** JSON-LD structured data found on StepStone job detail pages */
+export interface StepStoneJsonLd {
+  '@type': 'JobPosting';
+  title: string;
+  hiringOrganization?: {
+    name: string;
+  };
+  jobLocation?: {
+    address?: {
+      addressLocality?: string;
+      addressRegion?: string;
+      addressCountry?: string;
+    };
+  };
+  baseSalary?: {
+    currency?: string;
+    value?: {
+      minValue?: number;
+      maxValue?: number;
+    };
+  };
+  datePosted?: string;
+  employmentType?: string;
+  description?: string;
+}

--- a/packages/source-stepstone/tsconfig.json
+++ b/packages/source-stepstone/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../dist/packages/source-stepstone",
+    "declaration": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/source-wellfound/package.json
+++ b/packages/source-wellfound/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@ever-jobs/source-wellfound",
+  "version": "0.1.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "MIT"
+}

--- a/packages/source-wellfound/src/index.ts
+++ b/packages/source-wellfound/src/index.ts
@@ -1,0 +1,2 @@
+export { WellfoundModule } from './wellfound.module';
+export { WellfoundService } from './wellfound.service';

--- a/packages/source-wellfound/src/wellfound.constants.ts
+++ b/packages/source-wellfound/src/wellfound.constants.ts
@@ -1,0 +1,6 @@
+/** Wellfound jobs search URL */
+export const WELLFOUND_JOBS_URL = 'https://wellfound.com/jobs';
+
+/** Default delay between page requests (ms) */
+export const WELLFOUND_DELAY_MIN = 3000;
+export const WELLFOUND_DELAY_MAX = 7000;

--- a/packages/source-wellfound/src/wellfound.module.ts
+++ b/packages/source-wellfound/src/wellfound.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { WellfoundService } from './wellfound.service';
+
+@Module({
+  providers: [WellfoundService],
+  exports: [WellfoundService],
+})
+export class WellfoundModule {}

--- a/packages/source-wellfound/src/wellfound.service.ts
+++ b/packages/source-wellfound/src/wellfound.service.ts
@@ -1,0 +1,215 @@
+// WIP: This source may need selector updates after live testing.
+// Wellfound is a React/Next.js SPA with anti-bot measures.
+// Primary strategy: extract __NEXT_DATA__ from rendered page via Playwright.
+import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
+import {
+  IScraper,
+  ScraperInputDto,
+  JobResponseDto,
+  JobPostDto,
+  LocationDto,
+  CompensationDto,
+  CompensationInterval,
+  Site,
+  DescriptionFormat,
+} from '@ever-jobs/models';
+import {
+  htmlToPlainText,
+  markdownConverter,
+  extractEmails,
+  randomSleep,
+} from '@ever-jobs/common';
+import { BrowserPool } from '@ever-jobs/common';
+import { WELLFOUND_JOBS_URL, WELLFOUND_DELAY_MIN, WELLFOUND_DELAY_MAX } from './wellfound.constants';
+import { WellfoundNextData, WellfoundListing } from './wellfound.types';
+
+@Injectable()
+export class WellfoundService implements IScraper, OnModuleDestroy {
+  private readonly logger = new Logger(WellfoundService.name);
+
+  async scrape(input: ScraperInputDto): Promise<JobResponseDto> {
+    const proxy = input.proxies?.[0] ?? undefined;
+    const resultsWanted = input.resultsWanted ?? 15;
+    let page;
+
+    try {
+      page = await BrowserPool.getPage({ proxy });
+      const timeoutMs = (input.requestTimeout ?? 30) * 1000;
+
+      const url = new URL(WELLFOUND_JOBS_URL);
+      if (input.searchTerm) url.searchParams.set('q', input.searchTerm);
+
+      this.logger.log(`Wellfound: navigating to ${url.toString()}`);
+      await page.goto(url.toString(), {
+        waitUntil: 'domcontentloaded',
+        timeout: timeoutMs,
+      });
+
+      // Wait for Next.js hydration
+      await this.delay(6000);
+
+      // Extract __NEXT_DATA__ from the page
+      const nextDataJson = await page.evaluate(
+        `(() => { const s = document.getElementById('__NEXT_DATA__'); return s ? s.textContent : null; })()`,
+      ) as string | null;
+
+      if (!nextDataJson) {
+        // TODO: Try alternative extraction (Apollo state, direct DOM parsing)
+        this.logger.warn('Wellfound: __NEXT_DATA__ not found — page structure may have changed');
+        return new JobResponseDto([]);
+      }
+
+      let nextData: WellfoundNextData;
+      try {
+        nextData = JSON.parse(nextDataJson);
+      } catch {
+        this.logger.error('Wellfound: failed to parse __NEXT_DATA__ JSON');
+        return new JobResponseDto([]);
+      }
+
+      // TODO: Validate the exact path to job listings in __NEXT_DATA__
+      // Wellfound may nest listings under different keys depending on the page
+      const listings = this.extractListings(nextData);
+
+      if (listings.length === 0) {
+        this.logger.warn(
+          'Wellfound: zero listings found in __NEXT_DATA__ — data structure may have changed',
+        );
+      }
+
+      this.logger.log(`Wellfound: found ${listings.length} listings`);
+
+      const jobPosts: JobPostDto[] = [];
+      for (const listing of listings) {
+        if (jobPosts.length >= resultsWanted) break;
+
+        try {
+          const post = this.mapListing(listing, input.descriptionFormat);
+          if (post) jobPosts.push(post);
+        } catch (err: any) {
+          this.logger.debug(`Wellfound: failed to map listing: ${err.message}`);
+        }
+      }
+
+      return new JobResponseDto(jobPosts);
+    } catch (err: any) {
+      this.logger.error(`Wellfound scrape failed: ${err.message}`);
+      return new JobResponseDto([]);
+    } finally {
+      if (page) {
+        const context = page.context();
+        await page.close().catch(() => {});
+        await context.close().catch(() => {});
+      }
+    }
+  }
+
+  /**
+   * Recursively search __NEXT_DATA__ for arrays that look like job listings.
+   * TODO: Pin down exact path after validating against live site.
+   */
+  private extractListings(data: WellfoundNextData): WellfoundListing[] {
+    // Try common paths
+    const pageProps = data.props?.pageProps;
+    if (pageProps?.listings && Array.isArray(pageProps.listings)) {
+      return pageProps.listings;
+    }
+    if (pageProps?.jobs && Array.isArray(pageProps.jobs)) {
+      return pageProps.jobs;
+    }
+
+    // Deep search: look for arrays of objects with 'title' and 'company' fields
+    const found = this.findListingsDeep(data, 3);
+    return found;
+  }
+
+  private findListingsDeep(obj: unknown, maxDepth: number): WellfoundListing[] {
+    if (maxDepth <= 0 || !obj || typeof obj !== 'object') return [];
+
+    if (Array.isArray(obj)) {
+      // Check if this array looks like job listings
+      const sample = obj[0];
+      if (
+        sample &&
+        typeof sample === 'object' &&
+        'title' in sample &&
+        ('company' in sample || 'companyName' in sample)
+      ) {
+        return obj as WellfoundListing[];
+      }
+      return [];
+    }
+
+    for (const value of Object.values(obj)) {
+      const result = this.findListingsDeep(value, maxDepth - 1);
+      if (result.length > 0) return result;
+    }
+
+    return [];
+  }
+
+  private mapListing(
+    listing: WellfoundListing,
+    format?: DescriptionFormat,
+  ): JobPostDto | null {
+    if (!listing.title) return null;
+
+    const id = `wellfound-${listing.id}`;
+    const companyName = listing.company?.name ?? null;
+    const companySlug = listing.company?.slug ?? '';
+    const jobSlug = listing.slug ?? String(listing.id);
+    const jobUrl = `https://wellfound.com/jobs/${jobSlug}`;
+
+    let description: string | null = null;
+    if (listing.description) {
+      if (format === DescriptionFormat.HTML) {
+        description = listing.description;
+      } else if (format === DescriptionFormat.MARKDOWN) {
+        description = markdownConverter(listing.description) ?? listing.description;
+      } else {
+        description = htmlToPlainText(listing.description);
+      }
+    }
+
+    const locationStr = listing.locations?.[0] ?? null;
+    const location = locationStr ? new LocationDto({ city: locationStr }) : null;
+
+    let compensation: CompensationDto | null = null;
+    if (listing.compensation?.min != null || listing.compensation?.max != null) {
+      compensation = new CompensationDto({
+        interval: CompensationInterval.YEARLY,
+        minAmount: listing.compensation.min ?? undefined,
+        maxAmount: listing.compensation.max ?? undefined,
+        currency: listing.compensation.currency ?? 'USD',
+      });
+    }
+
+    const datePosted = listing.createdAt
+      ? new Date(listing.createdAt).toISOString().split('T')[0]
+      : null;
+
+    return new JobPostDto({
+      id,
+      title: listing.title,
+      companyName,
+      companyLogo: listing.company?.logoUrl ?? null,
+      jobUrl,
+      location,
+      description,
+      compensation,
+      datePosted,
+      isRemote: listing.remote ?? false,
+      emails: extractEmails(description),
+      site: Site.WELLFOUND,
+      skills: listing.skills?.length ? listing.skills : null,
+    });
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await BrowserPool.close();
+  }
+
+  private delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}

--- a/packages/source-wellfound/src/wellfound.types.ts
+++ b/packages/source-wellfound/src/wellfound.types.ts
@@ -1,0 +1,44 @@
+/**
+ * TypeScript interfaces for Wellfound (AngelList) job listings.
+ * Extracted from __NEXT_DATA__ or Apollo state embedded in the page.
+ *
+ * TODO: Validate against live Wellfound page structure
+ */
+
+export interface WellfoundNextData {
+  props?: {
+    pageProps?: {
+      listings?: WellfoundListing[];
+      jobs?: WellfoundListing[];
+      [key: string]: unknown;
+    };
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+export interface WellfoundListing {
+  id: string | number;
+  title: string;
+  slug?: string;
+  company?: {
+    name: string;
+    slug?: string;
+    logoUrl?: string;
+    highConcept?: string;
+    companySize?: string;
+  };
+  compensation?: {
+    min?: number | null;
+    max?: number | null;
+    currency?: string;
+    equity?: boolean;
+    equityMin?: number | null;
+    equityMax?: number | null;
+  };
+  locations?: string[];
+  remote?: boolean;
+  description?: string;
+  skills?: string[];
+  createdAt?: string;
+}

--- a/packages/source-wellfound/tsconfig.json
+++ b/packages/source-wellfound/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../dist/packages/source-wellfound",
+    "declaration": true
+  },
+  "include": ["src/**/*"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -59,7 +59,14 @@
       "@ever-jobs/source-adzuna": ["packages/source-adzuna/src/index.ts"],
       "@ever-jobs/source-reed": ["packages/source-reed/src/index.ts"],
       "@ever-jobs/source-jooble": ["packages/source-jooble/src/index.ts"],
-      "@ever-jobs/source-careerjet": ["packages/source-careerjet/src/index.ts"]
+      "@ever-jobs/source-careerjet": ["packages/source-careerjet/src/index.ts"],
+      "@ever-jobs/source-ats-bamboohr": ["packages/source-ats-bamboohr/src/index.ts"],
+      "@ever-jobs/source-ats-personio": ["packages/source-ats-personio/src/index.ts"],
+      "@ever-jobs/source-ats-jazzhr": ["packages/source-ats-jazzhr/src/index.ts"],
+      "@ever-jobs/source-dice": ["packages/source-dice/src/index.ts"],
+      "@ever-jobs/source-simplyhired": ["packages/source-simplyhired/src/index.ts"],
+      "@ever-jobs/source-wellfound": ["packages/source-wellfound/src/index.ts"],
+      "@ever-jobs/source-stepstone": ["packages/source-stepstone/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary

- Add **7 new job source integrations** (Phase 3 / Tier 2): BambooHR, Personio, JazzHR (ATS) and Dice, SimplyHired, Wellfound, StepStone (job boards)
- Total sources expanded from **39 → 46**
- All sources support **proxy pass-through** (HTTP via `createHttpClient`, Playwright via `BrowserPool`)
- 2 sources complete (BambooHR, Personio), 5 marked **WIP** with `// TODO:` and `// WIP:` comments for selector validation

### New Packages (7)

| Package | Type | Method | Status |
|---------|------|--------|--------|
| `source-ats-bamboohr` | ATS | Public JSON API | ✅ Complete |
| `source-ats-personio` | ATS | Public XML feed | ✅ Complete |
| `source-ats-jazzhr` | ATS | HTML scraping (cheerio) | 🚧 WIP |
| `source-dice` | Job Board | Cheerio + Playwright fallback | 🚧 WIP |
| `source-simplyhired` | Job Board | Cheerio + Playwright fallback | 🚧 WIP |
| `source-wellfound` | Job Board | Playwright SPA (`__NEXT_DATA__`) | 🚧 WIP |
| `source-stepstone` | Job Board | Playwright SPA (Germany `.de`) | 🚧 WIP |

### Docs Updated

- `README.md` — Source counts and tables (39→46)
- `docs/API_CHANGELOG.md` — New `[0.3.0]` entry
- `docs/ROADMAP.md` — Phase 3 in Current, version bump to v0.3.x
- `docs/PRD_NEW_JOB_SOURCES.md` — Phase 3 status with per-source tracking

### Integration

- 7 new `Site` enum values
- 7 new modules wired into `jobs.module.ts`
- 7 new services wired into `jobs.service.ts` (scraperMap + ATS_SITES)
- 7 new path mappings in `tsconfig.base.json`
- No new npm dependencies (cheerio + playwright already installed)

## Test plan

- [x] TypeScript compilation passes (`npx tsc -p tsconfig.base.json --noEmit`)
- [ ] Smoke test BambooHR with a public company slug
- [ ] Smoke test Personio with a public company slug
- [ ] Validate WIP source selectors against live sites
- [ ] Verify existing sources unaffected (run default search)

🤖 Generated with [Claude Code](https://claude.com/claude-code)