### PR TITLE
fix(models): preserve default currency when no symbol is present

### DIFF
--- a/packages/models/src/dtos/compensation.dto.ts
+++ b/packages/models/src/dtos/compensation.dto.ts
@@ -8,6 +8,11 @@ export class CompensationDto {
 
   constructor(partial?: Partial<CompensationDto>) {
     this.currency = 'USD';
-    Object.assign(this, partial);
+    if (partial) {
+      const clean = Object.fromEntries(
+        Object.entries(partial).filter(([, v]) => v !== undefined),
+      );
+      Object.assign(this, clean);
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Fix regression where `CompensationDto` loses its `'USD'` default currency when callers pass `currency: undefined`
- `Object.assign` overwrites the default with `undefined` — now filters out undefined values before assigning
- Affects Jooble (and any future source where `detectCurrency` finds no symbol)

## Test plan

- [x] TypeScript compilation passes
- [ ] `new CompensationDto({ currency: undefined })` preserves `'USD'`
- [ ] `new CompensationDto({ currency: 'EUR' })` correctly sets `'EUR'`
- [ ] `new CompensationDto({})` preserves `'USD'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)