### PR TITLE
feat: add Jobvite, ADP, UKG ATS integrations and comprehensive ATS docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## ⭐️ Overview
 
-**Ever Jobs** searches job postings from **51 sources** concurrently and returns aggregated, normalized results through a single REST API **or CLI**. Sources span search-based job boards, ATS (Applicant Tracking System) boards, and company-specific career APIs. Each source is an independent, reusable NestJS package — making it easy to add new sources, consume individual packages in other projects, or deploy the full API.
+**Ever Jobs** searches job postings from **54 sources** concurrently and returns aggregated, normalized results through a single REST API **or CLI**. Sources span search-based job boards, ATS (Applicant Tracking System) boards, and company-specific career APIs. Each source is an independent, reusable NestJS package — making it easy to add new sources, consume individual packages in other projects, or deploy the full API.
 
 ### Search-Based Job Boards (28)
 
@@ -44,27 +44,30 @@
 | **Monster**            | API + Playwright       | Global                      |
 | **CareerBuilder**      | HTML + Playwright      | US                          |
 
-### ATS Job Boards (15)
+### ATS Job Boards (18)
 
-ATS scrapers require a `companySlug` to target a specific company's job board.
+ATS scrapers require a `companySlug` to target a specific company's job board. Ever Jobs integrates directly with each ATS platform's structured API, detecting new postings at the source — often hours before they appear on aggregated job boards like LinkedIn or Indeed.
 
-| Source              | ATS Platform    | Method      |
-| ------------------- | --------------- | ----------- |
-| **Ashby**           | Ashby           | REST API    |
-| **Greenhouse**      | Greenhouse      | REST API    |
-| **Lever**           | Lever           | REST API    |
-| **Workable**        | Workable        | GraphQL API |
-| **SmartRecruiters** | SmartRecruiters | REST API    |
-| **Rippling**        | Rippling        | REST API    |
-| **Workday**         | Workday         | REST API    |
-| **Recruitee**       | Recruitee       | REST API    |
-| **Teamtailor**      | Teamtailor      | REST API    |
-| **BambooHR**        | BambooHR        | REST API (JSON) |
-| **Personio**        | Personio        | XML feed        |
-| **JazzHR**          | JazzHR          | HTML scraping   |
-| **iCIMS**           | iCIMS           | Playwright + JSON gateway |
-| **Taleo**           | Oracle Taleo    | REST API (JSON) |
-| **SuccessFactors**  | SAP SuccessFactors | OData API + HTML fallback |
+| Source              | ATS Platform       | Method                    | Notable Users                                       |
+| ------------------- | ------------------ | ------------------------- | --------------------------------------------------- |
+| **Greenhouse**      | Greenhouse         | REST API                  | Airbnb, Coinbase, Datadog, DoorDash, HubSpot, Notion, Stripe |
+| **Lever**           | Lever              | REST API                  | Netflix, Shopify, KPMG, Eventbrite, Atlassian       |
+| **Workday**         | Workday            | REST API                  | Amazon, Salesforce, Target, Bank of America, Visa   |
+| **Ashby**           | Ashby              | REST API                  | Ramp, Figma, Linear, Vercel, Plaid                  |
+| **SmartRecruiters** | SmartRecruiters    | REST API                  | Visa, Bosch, LinkedIn, Skechers, Equinox            |
+| **Jobvite**         | Jobvite            | REST API                  | Logitech, Schneider Electric, Zappos                |
+| **Workable**        | Workable           | GraphQL API               | Sephora, Bain Capital, Forbes                       |
+| **SAP SuccessFactors** | SAP SuccessFactors | OData API + HTML fallback | Siemens, Accenture, Deloitte, EY                 |
+| **Oracle Taleo**    | Oracle Taleo       | REST API (JSON)           | JPMorgan Chase, PepsiCo, Intel, Cisco               |
+| **iCIMS**           | iCIMS              | Playwright + JSON gateway | UPS, Uber, Johnson & Johnson, Target                |
+| **ADP Recruiting**  | ADP Workforce Now  | REST API                  | Major enterprises across industries                 |
+| **UKG (UltiPro)**   | UKG Pro Recruiting | REST API                  | Major healthcare and manufacturing organizations    |
+| **Rippling**        | Rippling           | REST API                  |                                                     |
+| **Recruitee**       | Recruitee          | REST API                  |                                                     |
+| **Teamtailor**      | Teamtailor         | REST API                  |                                                     |
+| **BambooHR**        | BambooHR           | REST API (JSON)           |                                                     |
+| **Personio**        | Personio           | XML feed                  |                                                     |
+| **JazzHR**          | JazzHR             | HTML scraping             |                                                     |
 
 ### Company-Specific Scrapers (7)
 
@@ -84,7 +87,7 @@ Direct integrations with major tech companies' career APIs.
 
 ## ✨ Features
 
-- 🔍 **Multi-source aggregation** — Search 1 or all 51 sources concurrently
+- 🔍 **Multi-source aggregation** — Search 1 or all 54 sources concurrently
 - 🖥️ **CLI & API** — Use via REST API or command-line with JSON, CSV, table, or summary output
 - 🌐 **Country-aware** — Indeed & Glassdoor support 65+ countries with automatic domain resolution
 - 🔄 **Proxy rotation** — Built-in rotating proxy support (HTTP, HTTPS, SOCKS5)
@@ -329,7 +332,7 @@ All parameters are optional. When `siteType` is omitted, search + company scrape
 
 | Parameter                  | Type       | Default    | Description                                                                                                                                                                                                                                                                                                                             |
 | -------------------------- | ---------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `siteType`                 | `string[]` | all        | Sites to search. **Search**: `linkedin`, `indeed`, `zip_recruiter`, `glassdoor`, `google`, `bayt`, `naukri`, `bdjobs`, `internshala`, `exa`, `upwork`, `remoteok`, `remotive`, `jobicy`, `himalayas`, `arbeitnow`, `weworkremotely`, `usajobs`, `adzuna`, `reed`, `jooble`, `careerjet`, `dice`, `simplyhired`, `wellfound`, `stepstone`, `monster`, `careerbuilder`. **ATS**: `ashby`, `greenhouse`, `lever`, `workable`, `smartrecruiters`, `rippling`, `workday`, `recruitee`, `teamtailor`, `bamboohr`, `personio`, `jazzhr`, `icims`, `taleo`, `successfactors`. **Company**: `amazon`, `apple`, `microsoft`, `nvidia`, `tiktok`, `uber`, `cursor` |
+| `siteType`                 | `string[]` | all        | Sites to search. **Search**: `linkedin`, `indeed`, `zip_recruiter`, `glassdoor`, `google`, `bayt`, `naukri`, `bdjobs`, `internshala`, `exa`, `upwork`, `remoteok`, `remotive`, `jobicy`, `himalayas`, `arbeitnow`, `weworkremotely`, `usajobs`, `adzuna`, `reed`, `jooble`, `careerjet`, `dice`, `simplyhired`, `wellfound`, `stepstone`, `monster`, `careerbuilder`. **ATS**: `ashby`, `greenhouse`, `lever`, `workable`, `smartrecruiters`, `rippling`, `workday`, `recruitee`, `teamtailor`, `bamboohr`, `personio`, `jazzhr`, `icims`, `taleo`, `successfactors`, `jobvite`, `adp`, `ukg`. **Company**: `amazon`, `apple`, `microsoft`, `nvidia`, `tiktok`, `uber`, `cursor` |
 | `companySlug`              | `string`   | —          | Company identifier for ATS scrapers (e.g. `stripe`, `notion`). When set without `siteType`, only ATS scrapers run                                                                                                                                                                                                                       |
 | `searchTerm`               | `string`   | —          | Job search keywords                                                                                                                                                                                                                                                                                                                     |
 | `googleSearchTerm`         | `string`   | —          | Google-specific search query override                                                                                                                                                                                                                                                                                                   |
@@ -443,8 +446,8 @@ ever-jobs/
 │   ├── models/                       @ever-jobs/models
 │   ├── common/                       @ever-jobs/common (HttpClient, converters, utils)
 │   ├── analytics/                    @ever-jobs/analytics
-│   ├── source-*/                     Search source modules (×24)
-│   ├── source-ats-*/                 ATS source modules (×12)
+│   ├── source-*/                     Search source modules (×28)
+│   ├── source-ats-*/                 ATS source modules (×18)
 │   └── source-company-*/             Company-specific source modules (×7)
 │
 ├── .github/

--- a/apps/api/src/jobs/jobs.module.ts
+++ b/apps/api/src/jobs/jobs.module.ts
@@ -49,6 +49,9 @@ import { CareerBuilderModule } from '@ever-jobs/source-careerbuilder';
 import { IcimsModule } from '@ever-jobs/source-ats-icims';
 import { TaleoModule } from '@ever-jobs/source-ats-taleo';
 import { SuccessFactorsModule } from '@ever-jobs/source-ats-successfactors';
+import { JobviteModule } from '@ever-jobs/source-ats-jobvite';
+import { AdpModule } from '@ever-jobs/source-ats-adp';
+import { UkgModule } from '@ever-jobs/source-ats-ukg';
 import { AnalyticsModule } from '@ever-jobs/analytics';
 import { JobsController } from './jobs.controller';
 import { JobsService } from './jobs.service';
@@ -105,6 +108,9 @@ import { JobsService } from './jobs.service';
     IcimsModule,
     TaleoModule,
     SuccessFactorsModule,
+    JobviteModule,
+    AdpModule,
+    UkgModule,
     AnalyticsModule,
   ],
   controllers: [JobsController],

--- a/apps/api/src/jobs/jobs.service.ts
+++ b/apps/api/src/jobs/jobs.service.ts
@@ -54,6 +54,9 @@ import { CareerBuilderService } from '@ever-jobs/source-careerbuilder';
 import { IcimsService } from '@ever-jobs/source-ats-icims';
 import { TaleoService } from '@ever-jobs/source-ats-taleo';
 import { SuccessFactorsService } from '@ever-jobs/source-ats-successfactors';
+import { JobviteService } from '@ever-jobs/source-ats-jobvite';
+import { AdpService } from '@ever-jobs/source-ats-adp';
+import { UkgService } from '@ever-jobs/source-ats-ukg';
 
 @Injectable()
 export class JobsService {
@@ -111,6 +114,9 @@ export class JobsService {
     private readonly icimsService: IcimsService,
     private readonly taleoService: TaleoService,
     private readonly successFactorsService: SuccessFactorsService,
+    private readonly jobviteService: JobviteService,
+    private readonly adpService: AdpService,
+    private readonly ukgService: UkgService,
   ) {
     this.scraperMap = new Map<Site, IScraper>([
       [Site.LINKEDIN, this.linkedInService],
@@ -163,6 +169,9 @@ export class JobsService {
       [Site.ICIMS, this.icimsService],
       [Site.TALEO, this.taleoService],
       [Site.SUCCESSFACTORS, this.successFactorsService],
+      [Site.JOBVITE, this.jobviteService],
+      [Site.ADP, this.adpService],
+      [Site.UKG, this.ukgService],
     ]);
   }
 
@@ -184,6 +193,9 @@ export class JobsService {
     Site.ICIMS,
     Site.TALEO,
     Site.SUCCESSFACTORS,
+    Site.JOBVITE,
+    Site.ADP,
+    Site.UKG,
   ]);
 
   /** Company scrapers target a single company's career API directly */

--- a/apps/cli/src/cli.module.ts
+++ b/apps/cli/src/cli.module.ts
@@ -37,6 +37,21 @@ import { AdzunaModule } from '@ever-jobs/source-adzuna';
 import { ReedModule } from '@ever-jobs/source-reed';
 import { JoobleModule } from '@ever-jobs/source-jooble';
 import { CareerJetModule } from '@ever-jobs/source-careerjet';
+import { BambooHRModule } from '@ever-jobs/source-ats-bamboohr';
+import { PersonioModule } from '@ever-jobs/source-ats-personio';
+import { JazzHRModule } from '@ever-jobs/source-ats-jazzhr';
+import { DiceModule } from '@ever-jobs/source-dice';
+import { SimplyHiredModule } from '@ever-jobs/source-simplyhired';
+import { WellfoundModule } from '@ever-jobs/source-wellfound';
+import { StepStoneModule } from '@ever-jobs/source-stepstone';
+import { MonsterModule } from '@ever-jobs/source-monster';
+import { CareerBuilderModule } from '@ever-jobs/source-careerbuilder';
+import { IcimsModule } from '@ever-jobs/source-ats-icims';
+import { TaleoModule } from '@ever-jobs/source-ats-taleo';
+import { SuccessFactorsModule } from '@ever-jobs/source-ats-successfactors';
+import { JobviteModule } from '@ever-jobs/source-ats-jobvite';
+import { AdpModule } from '@ever-jobs/source-ats-adp';
+import { UkgModule } from '@ever-jobs/source-ats-ukg';
 import { AnalyticsModule } from '@ever-jobs/analytics';
 import { JobsService } from '../../api/src/jobs/jobs.service';
 import { SearchCommand } from './commands/search.command';
@@ -88,6 +103,25 @@ import { CompareCommand } from './commands/compare.command';
     ReedModule,
     JoobleModule,
     CareerJetModule,
+    // Phase 3 ATS sources
+    BambooHRModule,
+    PersonioModule,
+    JazzHRModule,
+    // Phase 3 Playwright sources
+    DiceModule,
+    SimplyHiredModule,
+    WellfoundModule,
+    StepStoneModule,
+    MonsterModule,
+    CareerBuilderModule,
+    // Phase 4 Tier 3 ATS sources
+    IcimsModule,
+    TaleoModule,
+    SuccessFactorsModule,
+    // Phase 5 ATS sources
+    JobviteModule,
+    AdpModule,
+    UkgModule,
     // Analytics
     AnalyticsModule,
   ],

--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -33,7 +33,7 @@ Client Request
 │          ▼           │
 │  ┌────────────────┐  │
 │  │ Source Modules │  │   ← LinkedIn, Indeed, Glassdoor, etc.
-│  │  (39 sources)  │  │   ← search (22) + ATS (9) + company (7) + 1 analytics
+│  │  (54 sources)  │  │   ← search (28) + ATS (18) + company (7) + 1 analytics
 │  └────────────────┘  │
 └──────────────────────┘
            │
@@ -54,7 +54,7 @@ Client Request
 | `HealthController`    | `/health` and `/ping` endpoints                |
 | `JobsService`         | Orchestrates concurrent multi-source searching |
 | `JobsController`      | `POST /api/jobs/search` and `/analyze`         |
-| Source Modules (×34)  | Search (×17) + ATS (×9) + Company (×7)         |
+| Source Modules (×53)  | Search (×28) + ATS (×18) + Company (×7)        |
 | `AnalyticsModule`     | Job data analysis and aggregation              |
 
 ## Project Structure
@@ -75,8 +75,8 @@ ever-jobs/
 │   ├── analytics/           # Job data analytics
 │   ├── common/              # Shared HTTP client, utilities
 │   ├── models/              # TypeScript interfaces & DTOs
-│   ├── source-*/            # Search source modules (×17)
-│   ├── source-ats-*/        # ATS source modules (×9)
+│   ├── source-*/            # Search source modules (×28)
+│   ├── source-ats-*/        # ATS source modules (×18)
 │   └── source-company-*/    # Company-specific source modules (×7)
 ├── Dockerfile               # Multi-stage Docker build
 ├── docker-compose.yml       # Production deployment

--- a/docs/ATS_INTEGRATIONS.md
+++ b/docs/ATS_INTEGRATIONS.md
@@ -1,0 +1,200 @@
+# ATS Integrations
+
+Ever Jobs integrates directly with **18 applicant tracking systems** that power career pages at thousands of companies worldwide. When a recruiter publishes a new role through any supported ATS, Ever Jobs detects the posting at the source — often hours before it appears on aggregated job boards like LinkedIn or Indeed.
+
+## How ATS Integration Works
+
+1. **Purpose-Built Adapters** — Each ATS has a dedicated scraper module that understands the platform's data format, API structure, and publishing workflow.
+2. **Direct Source Detection** — Ever Jobs reads from the ATS's structured JSON/XML feed or API endpoint, seeing jobs the moment they go live on the company's career page.
+3. **Normalized Output** — Despite each ATS having a different response schema, all results are normalized into the standard `JobPostDto` format with consistent fields across platforms.
+
+### Usage
+
+ATS scrapers require a `companySlug` parameter to identify which company's career page to query:
+
+```bash
+# Search Greenhouse jobs for Stripe
+curl -X POST http://localhost:3000/api/jobs/search \
+  -H 'Content-Type: application/json' \
+  -d '{"companySlug": "stripe", "siteType": ["greenhouse"]}'
+
+# Search all ATS platforms for a given company
+curl -X POST http://localhost:3000/api/jobs/search \
+  -H 'Content-Type: application/json' \
+  -d '{"companySlug": "notion"}'
+```
+
+When `companySlug` is provided without an explicit `siteType`, all 18 ATS scrapers run concurrently. Each one independently checks whether the company exists on its platform and returns results accordingly.
+
+---
+
+## Supported Platforms
+
+### Greenhouse
+
+The leading applicant tracking system for scaling companies. Known for structured hiring methodology with scorecards, interview plans, and evaluation criteria. Career pages typically hosted at `boards.greenhouse.io`.
+
+- **Method**: REST API (`api.greenhouse.io/v1/boards`)
+- **Data Format**: JSON with full job descriptions, departments, offices
+- **Notable Users**: Airbnb, Coinbase, Datadog, DoorDash, HubSpot, Notion, Stripe
+
+### Lever
+
+A talent acquisition suite combining ATS and CRM capabilities. Lever helps companies build and maintain candidate relationships throughout the hiring process, from sourcing to close.
+
+- **Method**: REST API (`jobs.lever.co`)
+- **Data Format**: JSON with team, location, commitment level
+- **Notable Users**: Netflix, Shopify, KPMG, Eventbrite, Atlassian
+
+### Workday
+
+Enterprise-grade human capital management platform used by the world's largest organizations. Workday Recruiting is a core module within its broader HR suite, handling requisitions, approvals, and candidate management at global scale.
+
+- **Method**: REST API (company-specific Workday endpoints)
+- **Data Format**: JSON with compensation, requisition metadata
+- **Notable Users**: Amazon, Salesforce, Target, Bank of America, Visa, Netflix
+
+### Ashby
+
+A modern, all-in-one recruiting platform purpose-built for high-growth companies. Ashby combines ATS, CRM, scheduling, and analytics into a single product, favored by technology companies that value data-driven hiring.
+
+- **Method**: REST API (`jobs.ashbyhq.com`)
+- **Data Format**: JSON with department, team, employment type
+- **Notable Users**: Ramp, Figma, Linear, Vercel, Plaid
+
+### SmartRecruiters
+
+Enterprise talent acquisition platform with a marketplace of integrated hiring tools. SmartRecruiters serves large organizations across industries globally, with strong compliance and reporting capabilities.
+
+- **Method**: REST API (`jobs.smartrecruiters.com`)
+- **Data Format**: JSON with location, department, experience level
+- **Notable Users**: Visa, Bosch, LinkedIn, Skechers, Equinox
+
+### Jobvite
+
+End-to-end talent acquisition suite covering recruitment marketing, ATS, and onboarding. Jobvite is recognized for its annual insights on hiring trends and candidate behavior.
+
+- **Method**: REST API (`jobs.jobvite.com`)
+- **Data Format**: JSON with requisition details, department, category
+- **Notable Users**: Logitech, Schneider Electric, Zappos
+
+### Workable
+
+Hiring platform designed for small and mid-sized businesses. Workable provides sourcing tools, an ATS, and AI-powered candidate recommendations, making it accessible for organizations without dedicated recruiting operations.
+
+- **Method**: GraphQL API (company-specific subdomains)
+- **Data Format**: JSON with requirements, benefits, location
+- **Notable Users**: Sephora, Bain Capital, Forbes
+
+### SAP SuccessFactors
+
+SAP's cloud-based human experience management suite used by large enterprises worldwide. SuccessFactors Recruiting handles talent acquisition at scale with deep integration into SAP's broader HR ecosystem.
+
+- **Method**: OData API with HTML fallback
+- **Data Format**: XML/JSON, full requisition details
+- **Notable Users**: Siemens, Accenture, Deloitte, EY
+
+### Oracle Taleo
+
+Oracle's enterprise talent management cloud and one of the most widely deployed ATS platforms globally, particularly among Fortune 500 companies. Taleo handles high-volume recruiting across complex organizational structures.
+
+- **Method**: REST API (JSON)
+- **Data Format**: JSON with requisition metadata, location hierarchy
+- **Notable Users**: JPMorgan Chase, PepsiCo, Intel, Cisco
+
+### iCIMS
+
+Talent cloud platform serving enterprise employers. iCIMS powers hiring for some of the world's largest workforces with tools spanning the entire talent lifecycle — from attraction and engagement to hiring and onboarding.
+
+- **Method**: Playwright + JSON gateway
+- **Data Format**: JSON via dynamic rendering
+- **Notable Users**: UPS, Uber, Johnson & Johnson, Target
+
+### ADP Recruiting
+
+Part of ADP's comprehensive HR platform, ADP Recruiting Management helps organizations streamline hiring from requisition to onboarding. Integrated with ADP Workforce Now, it provides unified HR and recruiting data for enterprises.
+
+- **Method**: REST API (ADP Workforce Now endpoints)
+- **Data Format**: JSON with requisition, location, compensation
+- **Notable Users**: Major enterprises across industries
+
+### UKG (UltiPro)
+
+UKG's talent acquisition module within its broader workforce management platform. UKG Pro Recruiting is used by mid-to-large organizations for end-to-end HR management, particularly strong in healthcare and manufacturing sectors.
+
+- **Method**: REST API (`recruiting.ultipro.com`)
+- **Data Format**: JSON with opportunity details, department, location
+- **Notable Users**: Major healthcare and manufacturing organizations
+
+### Rippling
+
+Modern HR platform that unifies employee management, payroll, benefits, and recruiting. Rippling's ATS integrates tightly with its broader HR suite, popular among technology companies.
+
+- **Method**: REST API
+- **Data Format**: JSON
+
+### Recruitee
+
+Collaborative hiring platform with an emphasis on employer branding. Recruitee provides public career page APIs with salary data when available.
+
+- **Method**: REST API (`{slug}.recruitee.com/api/offers`)
+- **Data Format**: JSON with salary, department, location
+
+### Teamtailor
+
+Swedish-origin employer branding and ATS platform focused on candidate experience. Teamtailor powers career sites with rich media and analytics.
+
+- **Method**: REST API (company-specific career page endpoints)
+- **Data Format**: JSON
+
+### BambooHR
+
+HR software designed for small and medium businesses. BambooHR's recruiting module provides public career page APIs with structured job and location data.
+
+- **Method**: REST API (`{slug}.bamboohr.com/careers/list`)
+- **Data Format**: JSON with department, location, employment status
+
+### Personio
+
+European-focused HR platform for small and mid-sized companies. Personio's recruiting module exposes job listings through XML feeds.
+
+- **Method**: XML feed
+- **Data Format**: XML with position details, department, location
+
+### JazzHR
+
+Recruiting software for small businesses. JazzHR provides career pages with job listings accessible through HTML scraping.
+
+- **Method**: HTML scraping
+- **Data Format**: HTML with job details, location, department
+
+---
+
+## Architecture
+
+Each ATS integration is an independent NestJS package following the `IScraper` interface:
+
+```
+packages/source-ats-{name}/
+  src/
+    index.ts              # Public exports
+    {name}.module.ts      # NestJS module
+    {name}.service.ts     # IScraper implementation
+    {name}.constants.ts   # API URLs, headers
+    {name}.types.ts       # Response type definitions
+```
+
+All ATS services are registered in `JobsService.ATS_SITES` and included in the scraper map, ensuring they run automatically when `companySlug` is provided.
+
+---
+
+## Adding a New ATS Integration
+
+See [PRD_NEW_JOB_SOURCES.md](PRD_NEW_JOB_SOURCES.md) for the step-by-step guide to implementing a new source. The key steps are:
+
+1. Create `packages/source-ats-{name}/` with the standard file structure
+2. Implement the `IScraper` interface in the service
+3. Add the `Site` enum entry in `packages/models/src/enums/site.enum.ts`
+4. Register the path in `tsconfig.base.json`
+5. Import the module in `apps/api/src/jobs/jobs.module.ts` and `apps/cli/src/cli.module.ts`
+6. Wire it into `JobsService` (constructor, scraper map, `ATS_SITES` set)

--- a/packages/models/src/enums/site.enum.ts
+++ b/packages/models/src/enums/site.enum.ts
@@ -49,6 +49,9 @@ export enum Site {
   ICIMS = 'icims',
   TALEO = 'taleo',
   SUCCESSFACTORS = 'successfactors',
+  JOBVITE = 'jobvite',
+  ADP = 'adp',
+  UKG = 'ukg',
 }
 
 /**

--- a/packages/source-ats-adp/package.json
+++ b/packages/source-ats-adp/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@ever-jobs/source-ats-adp",
+  "version": "0.1.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "MIT"
+}

--- a/packages/source-ats-adp/src/adp.constants.ts
+++ b/packages/source-ats-adp/src/adp.constants.ts
@@ -1,0 +1,19 @@
+/**
+ * ADP career site job search API endpoint.
+ * The slug is interpolated at runtime to build the company's career page URL.
+ */
+export const ADP_CAREERS_URL = 'https://workforcenow.adp.com/mascsr/default/mdf/recruitment/recruitment.html';
+
+/**
+ * ADP job search REST API endpoint.
+ * Uses a JSON-based search API behind the career portal.
+ */
+export const ADP_API_URL = 'https://workforcenow.adp.com/mascsr/default/careercenter/public/events/staffing/v1/job-requisitions';
+
+/** Default headers for ADP career site requests */
+export const ADP_HEADERS: Record<string, string> = {
+  Accept: 'application/json',
+  'Content-Type': 'application/json',
+  'User-Agent':
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129 Safari/537.36',
+};

--- a/packages/source-ats-adp/src/adp.module.ts
+++ b/packages/source-ats-adp/src/adp.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { AdpService } from './adp.service';
+
+@Module({
+  providers: [AdpService],
+  exports: [AdpService],
+})
+export class AdpModule {}

--- a/packages/source-ats-adp/src/adp.service.ts
+++ b/packages/source-ats-adp/src/adp.service.ts
@@ -1,0 +1,135 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  IScraper,
+  ScraperInputDto,
+  JobResponseDto,
+  JobPostDto,
+  LocationDto,
+  Site,
+  DescriptionFormat,
+} from '@ever-jobs/models';
+import {
+  createHttpClient,
+  htmlToPlainText,
+  markdownConverter,
+  extractEmails,
+} from '@ever-jobs/common';
+import { ADP_API_URL, ADP_HEADERS } from './adp.constants';
+import { AdpResponse, AdpJob } from './adp.types';
+
+@Injectable()
+export class AdpService implements IScraper {
+  private readonly logger = new Logger(AdpService.name);
+
+  async scrape(input: ScraperInputDto): Promise<JobResponseDto> {
+    const companySlug = input.companySlug;
+    if (!companySlug) {
+      this.logger.warn('No companySlug provided for ADP scraper');
+      return new JobResponseDto([]);
+    }
+
+    const client = createHttpClient({
+      proxies: input.proxies,
+      caCert: input.caCert,
+      timeout: input.requestTimeout,
+    });
+    client.setHeaders(ADP_HEADERS);
+
+    const url = `${ADP_API_URL}?cid=${encodeURIComponent(companySlug)}`;
+
+    try {
+      this.logger.log(`Fetching ADP jobs for company: ${companySlug}`);
+      const response = await client.get(url);
+      const data: AdpResponse = response.data ?? { jobRequisitions: [] };
+      const jobs = data.jobRequisitions ?? [];
+
+      this.logger.log(`ADP: found ${jobs.length} raw jobs for ${companySlug}`);
+
+      const resultsWanted = input.resultsWanted ?? 100;
+      const jobPosts: JobPostDto[] = [];
+
+      for (const job of jobs) {
+        if (jobPosts.length >= resultsWanted) break;
+
+        try {
+          const post = this.mapJob(job, companySlug, input.descriptionFormat);
+          if (post) {
+            jobPosts.push(post);
+          }
+        } catch (err: any) {
+          this.logger.warn(
+            `Error processing ADP job ${job.jobRequisitionId}: ${err.message}`,
+          );
+        }
+      }
+
+      return new JobResponseDto(jobPosts);
+    } catch (err: any) {
+      this.logger.error(
+        `ADP scrape error for ${companySlug}: ${err.message}`,
+      );
+      return new JobResponseDto([]);
+    }
+  }
+
+  private mapJob(
+    job: AdpJob,
+    companySlug: string,
+    format?: DescriptionFormat,
+  ): JobPostDto | null {
+    const title = job.jobTitle;
+    if (!title) return null;
+
+    // Description
+    let description: string | null = null;
+    const rawDesc = job.jobDescription ?? job.shortDescription ?? null;
+    if (rawDesc) {
+      if (format === DescriptionFormat.HTML) {
+        description = rawDesc;
+      } else if (format === DescriptionFormat.MARKDOWN) {
+        description = markdownConverter(rawDesc) ?? rawDesc;
+      } else {
+        description = htmlToPlainText(rawDesc);
+      }
+    }
+
+    // Location — prefer first location from array, fall back to single
+    const loc = job.locations?.[0] ?? job.location ?? null;
+    const location = loc
+      ? new LocationDto({
+          city: loc.city ?? null,
+          state: loc.stateProvince ?? null,
+          country: loc.country ?? null,
+        })
+      : null;
+
+    // Remote detection
+    const locationStr =
+      loc?.formattedAddress ?? loc?.city ?? '';
+    const isRemote = locationStr.toLowerCase().includes('remote');
+
+    // Job URL
+    const jobUrl =
+      job.externalUrl ??
+      `https://workforcenow.adp.com/mascsr/default/mdf/recruitment/recruitment.html?cid=${encodeURIComponent(companySlug)}&jobId=${job.jobRequisitionId ?? ''}`;
+
+    return new JobPostDto({
+      id: `adp-${job.jobRequisitionId ?? job.requisitionNumber ?? ''}`,
+      title,
+      companyName: job.companyName ?? companySlug,
+      jobUrl,
+      location,
+      description,
+      datePosted: job.postedDate
+        ? new Date(job.postedDate).toISOString().split('T')[0]
+        : null,
+      isRemote,
+      emails: extractEmails(description),
+      site: Site.ADP,
+      atsId: job.jobRequisitionId ?? job.requisitionNumber ?? null,
+      atsType: 'adp',
+      department: job.departmentName ?? null,
+      employmentType: job.employmentType ?? job.workerTypeCode ?? null,
+    });
+  }
+}

--- a/packages/source-ats-adp/src/adp.types.ts
+++ b/packages/source-ats-adp/src/adp.types.ts
@@ -1,0 +1,59 @@
+/**
+ * TypeScript interfaces for ADP Workforce Now career site API responses.
+ */
+
+export interface AdpResponse {
+  jobRequisitions?: AdpJob[];
+  meta?: {
+    totalCount?: number;
+  };
+}
+
+export interface AdpJob {
+  /** Unique job requisition ID */
+  jobRequisitionId?: string | null;
+  /** Requisition number */
+  requisitionNumber?: string | null;
+  /** Job title */
+  jobTitle?: string | null;
+  /** Job description (HTML or plain text) */
+  jobDescription?: string | null;
+  /** Short description / summary */
+  shortDescription?: string | null;
+  /** Department name */
+  departmentName?: string | null;
+  /** Location */
+  location?: AdpLocation | null;
+  /** Multiple locations */
+  locations?: AdpLocation[] | null;
+  /** Job type (Full-Time, Part-Time, etc.) */
+  workerTypeCode?: string | null;
+  /** Employment type description */
+  employmentType?: string | null;
+  /** External posting URL */
+  externalUrl?: string | null;
+  /** Posted date (ISO format) */
+  postedDate?: string | null;
+  /** Last updated date */
+  lastUpdatedDate?: string | null;
+  /** Company name */
+  companyName?: string | null;
+  /** Compensation info */
+  compensation?: {
+    minPay?: number | null;
+    maxPay?: number | null;
+    currency?: string | null;
+    frequency?: string | null;
+  } | null;
+}
+
+export interface AdpLocation {
+  /** City */
+  city?: string | null;
+  /** State / province code */
+  stateProvince?: string | null;
+  /** Country code */
+  country?: string | null;
+  /** Full address */
+  formattedAddress?: string | null;
+}

--- a/packages/source-ats-adp/src/index.ts
+++ b/packages/source-ats-adp/src/index.ts
@@ -1,0 +1,2 @@
+export { AdpModule } from './adp.module';
+export { AdpService } from './adp.service';

--- a/packages/source-ats-adp/tsconfig.json
+++ b/packages/source-ats-adp/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../dist/packages/source-ats-adp",
+    "declaration": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/source-ats-jobvite/package.json
+++ b/packages/source-ats-jobvite/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@ever-jobs/source-ats-jobvite",
+  "version": "0.1.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "MIT"
+}

--- a/packages/source-ats-jobvite/src/index.ts
+++ b/packages/source-ats-jobvite/src/index.ts
@@ -1,0 +1,2 @@
+export { JobviteModule } from './jobvite.module';
+export { JobviteService } from './jobvite.service';

--- a/packages/source-ats-jobvite/src/jobvite.constants.ts
+++ b/packages/source-ats-jobvite/src/jobvite.constants.ts
@@ -1,0 +1,12 @@
+/**
+ * Jobvite public career site JSON feed endpoint.
+ * The slug is interpolated at runtime: /api/v2/job-feed/{companyId}
+ */
+export const JOBVITE_API_URL = 'https://jobs.jobvite.com/api/v2/job-feed';
+
+/** Default headers for Jobvite career page requests */
+export const JOBVITE_HEADERS: Record<string, string> = {
+  Accept: 'application/json',
+  'User-Agent':
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129 Safari/537.36',
+};

--- a/packages/source-ats-jobvite/src/jobvite.module.ts
+++ b/packages/source-ats-jobvite/src/jobvite.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { JobviteService } from './jobvite.service';
+
+@Module({
+  providers: [JobviteService],
+  exports: [JobviteService],
+})
+export class JobviteModule {}

--- a/packages/source-ats-jobvite/src/jobvite.service.ts
+++ b/packages/source-ats-jobvite/src/jobvite.service.ts
@@ -1,0 +1,135 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  IScraper,
+  ScraperInputDto,
+  JobResponseDto,
+  JobPostDto,
+  LocationDto,
+  Site,
+  DescriptionFormat,
+} from '@ever-jobs/models';
+import {
+  createHttpClient,
+  htmlToPlainText,
+  markdownConverter,
+  extractEmails,
+} from '@ever-jobs/common';
+import { JOBVITE_API_URL, JOBVITE_HEADERS } from './jobvite.constants';
+import { JobviteResponse, JobviteJob } from './jobvite.types';
+
+@Injectable()
+export class JobviteService implements IScraper {
+  private readonly logger = new Logger(JobviteService.name);
+
+  async scrape(input: ScraperInputDto): Promise<JobResponseDto> {
+    const companySlug = input.companySlug;
+    if (!companySlug) {
+      this.logger.warn('No companySlug provided for Jobvite scraper');
+      return new JobResponseDto([]);
+    }
+
+    const client = createHttpClient({
+      proxies: input.proxies,
+      caCert: input.caCert,
+      timeout: input.requestTimeout,
+    });
+    client.setHeaders(JOBVITE_HEADERS);
+
+    const url = `${JOBVITE_API_URL}/${encodeURIComponent(companySlug)}`;
+
+    try {
+      this.logger.log(`Fetching Jobvite jobs for company: ${companySlug}`);
+      const response = await client.get(url);
+      const data: JobviteResponse = response.data ?? { requisitions: [] };
+      const jobs = data.requisitions ?? [];
+
+      this.logger.log(
+        `Jobvite: found ${jobs.length} raw jobs for ${companySlug}`,
+      );
+
+      const resultsWanted = input.resultsWanted ?? 100;
+      const jobPosts: JobPostDto[] = [];
+
+      for (const job of jobs) {
+        if (jobPosts.length >= resultsWanted) break;
+
+        try {
+          const post = this.mapJob(job, companySlug, input.descriptionFormat);
+          if (post) {
+            jobPosts.push(post);
+          }
+        } catch (err: any) {
+          this.logger.warn(
+            `Error processing Jobvite job ${job.eId}: ${err.message}`,
+          );
+        }
+      }
+
+      return new JobResponseDto(jobPosts);
+    } catch (err: any) {
+      this.logger.error(
+        `Jobvite scrape error for ${companySlug}: ${err.message}`,
+      );
+      return new JobResponseDto([]);
+    }
+  }
+
+  private mapJob(
+    job: JobviteJob,
+    companySlug: string,
+    format?: DescriptionFormat,
+  ): JobPostDto | null {
+    const title = job.title;
+    if (!title) return null;
+
+    // Description
+    let description: string | null = null;
+    const rawDesc = job.description ?? job.briefDescription ?? null;
+    if (rawDesc) {
+      if (format === DescriptionFormat.HTML) {
+        description = rawDesc;
+      } else if (format === DescriptionFormat.MARKDOWN) {
+        description = markdownConverter(rawDesc) ?? rawDesc;
+      } else {
+        description = htmlToPlainText(rawDesc);
+      }
+    }
+
+    // Location
+    const location = new LocationDto({
+      city: job.city ?? null,
+      state: job.state ?? null,
+      country: job.country ?? null,
+    });
+
+    // Remote detection
+    const locationStr = job.location ?? '';
+    const isRemote = locationStr.toLowerCase().includes('remote');
+
+    // Job URL
+    const jobUrl =
+      job.detailUrl ??
+      job.applyUrl ??
+      `https://jobs.jobvite.com/${encodeURIComponent(companySlug)}/job/${job.eId ?? ''}`;
+
+    return new JobPostDto({
+      id: `jobvite-${job.eId ?? job.requisitionId ?? ''}`,
+      title,
+      companyName: companySlug,
+      jobUrl,
+      location,
+      description,
+      datePosted: job.date
+        ? new Date(job.date).toISOString().split('T')[0]
+        : null,
+      isRemote,
+      emails: extractEmails(description),
+      site: Site.JOBVITE,
+      atsId: job.eId ?? job.requisitionId ?? null,
+      atsType: 'jobvite',
+      department: job.department ?? job.category ?? null,
+      employmentType: job.type ?? null,
+      applyUrl: job.applyUrl ?? null,
+    });
+  }
+}

--- a/packages/source-ats-jobvite/src/jobvite.types.ts
+++ b/packages/source-ats-jobvite/src/jobvite.types.ts
@@ -1,0 +1,41 @@
+/**
+ * TypeScript interfaces for Jobvite public career site API responses.
+ */
+
+export interface JobviteResponse {
+  requisitions: JobviteJob[];
+  total?: number;
+}
+
+export interface JobviteJob {
+  /** Unique job requisition ID */
+  eId?: string | null;
+  /** Job title */
+  title?: string | null;
+  /** Department name */
+  department?: string | null;
+  /** Category / team */
+  category?: string | null;
+  /** Location string (e.g. "San Francisco, CA") */
+  location?: string | null;
+  /** City */
+  city?: string | null;
+  /** State / region */
+  state?: string | null;
+  /** Country */
+  country?: string | null;
+  /** Job type (Full-Time, Part-Time, etc.) */
+  type?: string | null;
+  /** Date posted (ISO format or human-readable) */
+  date?: string | null;
+  /** Job description (HTML) */
+  description?: string | null;
+  /** Brief description / summary */
+  briefDescription?: string | null;
+  /** Application URL */
+  applyUrl?: string | null;
+  /** Job detail URL */
+  detailUrl?: string | null;
+  /** Requisition ID */
+  requisitionId?: string | null;
+}

--- a/packages/source-ats-jobvite/tsconfig.json
+++ b/packages/source-ats-jobvite/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../dist/packages/source-ats-jobvite",
+    "declaration": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/source-ats-ukg/package.json
+++ b/packages/source-ats-ukg/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@ever-jobs/source-ats-ukg",
+  "version": "0.1.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "MIT"
+}

--- a/packages/source-ats-ukg/src/index.ts
+++ b/packages/source-ats-ukg/src/index.ts
@@ -1,0 +1,2 @@
+export { UkgModule } from './ukg.module';
+export { UkgService } from './ukg.service';

--- a/packages/source-ats-ukg/src/ukg.constants.ts
+++ b/packages/source-ats-ukg/src/ukg.constants.ts
@@ -1,0 +1,12 @@
+/**
+ * UKG Pro Recruiting (formerly UltiPro) career site API endpoint.
+ * The slug (company-specific subdomain) is interpolated at runtime.
+ */
+export const UKG_API_URL = 'https://recruiting.ultipro.com';
+
+/** Default headers for UKG career site requests */
+export const UKG_HEADERS: Record<string, string> = {
+  Accept: 'application/json',
+  'User-Agent':
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129 Safari/537.36',
+};

--- a/packages/source-ats-ukg/src/ukg.module.ts
+++ b/packages/source-ats-ukg/src/ukg.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { UkgService } from './ukg.service';
+
+@Module({
+  providers: [UkgService],
+  exports: [UkgService],
+})
+export class UkgModule {}

--- a/packages/source-ats-ukg/src/ukg.service.ts
+++ b/packages/source-ats-ukg/src/ukg.service.ts
@@ -1,0 +1,136 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  IScraper,
+  ScraperInputDto,
+  JobResponseDto,
+  JobPostDto,
+  LocationDto,
+  Site,
+  DescriptionFormat,
+} from '@ever-jobs/models';
+import {
+  createHttpClient,
+  htmlToPlainText,
+  markdownConverter,
+  extractEmails,
+} from '@ever-jobs/common';
+import { UKG_API_URL, UKG_HEADERS } from './ukg.constants';
+import { UkgResponse, UkgJob } from './ukg.types';
+
+@Injectable()
+export class UkgService implements IScraper {
+  private readonly logger = new Logger(UkgService.name);
+
+  async scrape(input: ScraperInputDto): Promise<JobResponseDto> {
+    const companySlug = input.companySlug;
+    if (!companySlug) {
+      this.logger.warn('No companySlug provided for UKG scraper');
+      return new JobResponseDto([]);
+    }
+
+    const client = createHttpClient({
+      proxies: input.proxies,
+      caCert: input.caCert,
+      timeout: input.requestTimeout,
+    });
+    client.setHeaders(UKG_HEADERS);
+
+    const url = `${UKG_API_URL}/${encodeURIComponent(companySlug)}/OpportunitySearch`;
+
+    try {
+      this.logger.log(`Fetching UKG jobs for company: ${companySlug}`);
+      const response = await client.get(url);
+      const data: UkgResponse = response.data ?? { opportunities: [] };
+      const jobs = data.opportunities ?? [];
+
+      this.logger.log(`UKG: found ${jobs.length} raw jobs for ${companySlug}`);
+
+      const resultsWanted = input.resultsWanted ?? 100;
+      const jobPosts: JobPostDto[] = [];
+
+      for (const job of jobs) {
+        if (jobPosts.length >= resultsWanted) break;
+
+        try {
+          const post = this.mapJob(job, companySlug, input.descriptionFormat);
+          if (post) {
+            jobPosts.push(post);
+          }
+        } catch (err: any) {
+          this.logger.warn(
+            `Error processing UKG job ${job.id}: ${err.message}`,
+          );
+        }
+      }
+
+      return new JobResponseDto(jobPosts);
+    } catch (err: any) {
+      this.logger.error(
+        `UKG scrape error for ${companySlug}: ${err.message}`,
+      );
+      return new JobResponseDto([]);
+    }
+  }
+
+  private mapJob(
+    job: UkgJob,
+    companySlug: string,
+    format?: DescriptionFormat,
+  ): JobPostDto | null {
+    const title = job.title;
+    if (!title) return null;
+
+    // Description
+    let description: string | null = null;
+    const rawDesc = job.description ?? job.shortDescription ?? null;
+    if (rawDesc) {
+      if (format === DescriptionFormat.HTML) {
+        description = rawDesc;
+      } else if (format === DescriptionFormat.MARKDOWN) {
+        description = markdownConverter(rawDesc) ?? rawDesc;
+      } else {
+        description = htmlToPlainText(rawDesc);
+      }
+    }
+
+    // Location — prefer first from array, fall back to single
+    const loc = job.locations?.[0] ?? job.location ?? null;
+    const location = loc
+      ? new LocationDto({
+          city: loc.city ?? null,
+          state: loc.state ?? null,
+          country: loc.country ?? null,
+        })
+      : null;
+
+    // Remote detection
+    const locationStr =
+      loc?.formattedAddress ?? loc?.city ?? '';
+    const isRemote = locationStr.toLowerCase().includes('remote');
+
+    // Job URL
+    const jobUrl =
+      job.applyUrl ??
+      `${UKG_API_URL}/${encodeURIComponent(companySlug)}/OpportunityDetail?opportunityId=${job.id ?? ''}`;
+
+    return new JobPostDto({
+      id: `ukg-${job.id ?? job.requisitionNumber ?? ''}`,
+      title,
+      companyName: job.companyName ?? companySlug,
+      jobUrl,
+      location,
+      description,
+      datePosted: job.postedDate
+        ? new Date(job.postedDate).toISOString().split('T')[0]
+        : null,
+      isRemote,
+      emails: extractEmails(description),
+      site: Site.UKG,
+      atsId: job.id ?? job.requisitionNumber ?? null,
+      atsType: 'ukg',
+      department: job.department ?? job.category ?? null,
+      employmentType: job.jobType ?? null,
+      applyUrl: job.applyUrl ?? null,
+    });
+  }
+}

--- a/packages/source-ats-ukg/src/ukg.types.ts
+++ b/packages/source-ats-ukg/src/ukg.types.ts
@@ -1,0 +1,52 @@
+/**
+ * TypeScript interfaces for UKG Pro Recruiting (UltiPro) career site API responses.
+ */
+
+export interface UkgResponse {
+  opportunities?: UkgJob[];
+  totalCount?: number;
+}
+
+export interface UkgJob {
+  /** Unique opportunity / job posting ID */
+  id?: string | null;
+  /** Job title */
+  title?: string | null;
+  /** Job description (HTML) */
+  description?: string | null;
+  /** Short description / summary */
+  shortDescription?: string | null;
+  /** Department name */
+  department?: string | null;
+  /** Category */
+  category?: string | null;
+  /** Location */
+  location?: UkgLocation | null;
+  /** Multiple locations */
+  locations?: UkgLocation[] | null;
+  /** Job type / employment type (Full-Time, Part-Time, etc.) */
+  jobType?: string | null;
+  /** Shift / schedule */
+  shift?: string | null;
+  /** Date posted (ISO format) */
+  postedDate?: string | null;
+  /** Last updated date */
+  updatedDate?: string | null;
+  /** Application URL */
+  applyUrl?: string | null;
+  /** Company name */
+  companyName?: string | null;
+  /** Requisition number */
+  requisitionNumber?: string | null;
+}
+
+export interface UkgLocation {
+  /** City */
+  city?: string | null;
+  /** State / province */
+  state?: string | null;
+  /** Country */
+  country?: string | null;
+  /** Full formatted address */
+  formattedAddress?: string | null;
+}

--- a/packages/source-ats-ukg/tsconfig.json
+++ b/packages/source-ats-ukg/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../dist/packages/source-ats-ukg",
+    "declaration": true
+  },
+  "include": ["src/**/*"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -71,7 +71,10 @@
       "@ever-jobs/source-careerbuilder": ["packages/source-careerbuilder/src/index.ts"],
       "@ever-jobs/source-ats-icims": ["packages/source-ats-icims/src/index.ts"],
       "@ever-jobs/source-ats-taleo": ["packages/source-ats-taleo/src/index.ts"],
-      "@ever-jobs/source-ats-successfactors": ["packages/source-ats-successfactors/src/index.ts"]
+      "@ever-jobs/source-ats-successfactors": ["packages/source-ats-successfactors/src/index.ts"],
+      "@ever-jobs/source-ats-jobvite": ["packages/source-ats-jobvite/src/index.ts"],
+      "@ever-jobs/source-ats-adp": ["packages/source-ats-adp/src/index.ts"],
+      "@ever-jobs/source-ats-ukg": ["packages/source-ats-ukg/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary
- Add 3 new ATS integrations: **Jobvite**, **ADP Recruiting** (Workforce Now), and **UKG** (UltiPro), bringing total ATS count to **18** and overall sources to **54**
- Create comprehensive `docs/ATS_INTEGRATIONS.md` documenting all 18 ATS platforms with descriptions, API methods, data formats, and notable company users
- Enrich README ATS table with Notable Users column (e.g., Greenhouse → Airbnb, Coinbase, Stripe; Lever → Netflix, Shopify, Atlassian)
- Sync CLI module with all previously missing source imports from Phases 3–4

## Changes
- **New packages**: `source-ats-jobvite`, `source-ats-adp`, `source-ats-ukg` — each with standard IScraper implementation
- **Updated**: Site enum, tsconfig paths, JobsModule, JobsService (constructor, scraperMap, ATS_SITES), CliModule
- **Docs**: New ATS_INTEGRATIONS.md, updated README.md and ARCHITECTURE_OVERVIEW.md with correct counts and enriched content

## Test plan
- [ ] Verify `npx tsc --noEmit` passes with zero errors
- [ ] Test ATS search with `companySlug` to confirm new sources are included in concurrent scraping
- [ ] Verify CLI imports resolve correctly
- [ ] Spot-check documentation accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)