### PR TITLE
Fix SimplyHired detail descriptions

### DIFF
--- a/.gitea/workflows/mirror-to-github.yml
+++ b/.gitea/workflows/mirror-to-github.yml
@@ -1,0 +1,39 @@
+name: Mirror to GitHub
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+      - "fix/**"
+      - "feature/**"
+  workflow_dispatch:
+
+concurrency:
+  group: mirror-to-github-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout full history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Push branch and tags to GitHub mirror
+        env:
+          GH_MIRROR_TOKEN: ${{ secrets.GITHUBPAT }}
+          GH_MIRROR_REPO: fgrosswig/ever-jobs
+        run: |
+          set -eu
+          if [ -z "${GH_MIRROR_TOKEN}" ]; then
+            echo "GITHUBPAT secret is required"
+            exit 1
+          fi
+
+          BRANCH="${GITHUB_REF_NAME:-${GITHUB_REF#refs/heads/}}"
+          git remote add github-mirror "https://x-access-token:${GH_MIRROR_TOKEN}@github.com/${GH_MIRROR_REPO}.git"
+          git push github-mirror "HEAD:${BRANCH}"
+          git push github-mirror --tags

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -1,7 +1,7 @@
 name: Build and Publish Ever Jobs Image
 
 # Builds the Ever Jobs container (API; MCP shares the image) and pushes it to GHCR
-# (ghcr.io/ever-jobs/ever-jobs) using the built-in GITHUB_TOKEN. The k8s-gauzy cluster
+# under the current repository owner using the built-in GITHUB_TOKEN. The k8s-gauzy cluster
 # pulls this image for the INTERNAL (ClusterIP-only) Ever Jobs deployment.
 on:
   push:
@@ -49,9 +49,9 @@ jobs:
           push: true
           platforms: linux/amd64
           tags: |
-            ghcr.io/ever-jobs/ever-jobs:latest
-            ghcr.io/ever-jobs/ever-jobs:${{ github.sha }}
-          cache-from: type=registry,ref=ghcr.io/ever-jobs/ever-jobs:latest
+            ghcr.io/${{ github.repository_owner }}/ever-jobs:latest
+            ghcr.io/${{ github.repository_owner }}/ever-jobs:${{ github.sha }}
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/ever-jobs:latest
           cache-to: type=inline
 
   build-mcp:
@@ -75,7 +75,7 @@ jobs:
           push: true
           platforms: linux/amd64
           tags: |
-            ghcr.io/ever-jobs/ever-jobs-mcp:latest
-            ghcr.io/ever-jobs/ever-jobs-mcp:${{ github.sha }}
-          cache-from: type=registry,ref=ghcr.io/ever-jobs/ever-jobs-mcp:latest
+            ghcr.io/${{ github.repository_owner }}/ever-jobs-mcp:latest
+            ghcr.io/${{ github.repository_owner }}/ever-jobs-mcp:${{ github.sha }}
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/ever-jobs-mcp:latest
           cache-to: type=inline

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,12 +1,20 @@
 import { NestFactory } from '@nestjs/core';
-import { ValidationPipe, Logger } from '@nestjs/common';
+import { ValidationPipe, Logger, LogLevel } from '@nestjs/common';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { apiReference } from '@scalar/nestjs-api-reference';
 import { ConfigService } from '@nestjs/config';
 import { AppModule } from './app.module';
 
+function resolveLogLevels(): LogLevel[] {
+  // LOG_LEVEL kumulativ auf den Nest-Logger anwenden (Env wurde bisher gelesen, nie genutzt).
+  const order: LogLevel[] = ['error', 'warn', 'log', 'debug', 'verbose'];
+  const map: Record<string, number> = { error: 0, warn: 1, info: 2, log: 2, debug: 3, verbose: 4 };
+  const idx = map[(process.env.LOG_LEVEL || 'info').toLowerCase()] ?? 2;
+  return order.slice(0, idx + 1);
+}
+
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create(AppModule, { logger: resolveLogLevels() });
   const config = app.get(ConfigService);
   const logger = new Logger('Bootstrap');
 

--- a/packages/plugins/source-simplyhired/__tests__/simplyhired.service.spec.ts
+++ b/packages/plugins/source-simplyhired/__tests__/simplyhired.service.spec.ts
@@ -1,0 +1,88 @@
+import { DescriptionFormat } from '@ever-jobs/models';
+import { SimplyHiredService } from '../src/simplyhired.service';
+
+describe('SimplyHiredService detail parsing', () => {
+  const service = new SimplyHiredService() as any;
+
+  it('uses JobPosting JSON-LD for the current job and ignores similar jobs', () => {
+    const html = `
+      <html>
+        <body>
+          <main>
+            <h1>Administrative Assistant</h1>
+            <section>
+              <h2>Job Details</h2>
+              <p>Full-time</p>
+              <p>$22.58 - $27.19 an hour</p>
+              <h2>Qualifications</h2>
+              <span>Administrative experience</span>
+              <span>Productivity software</span>
+              <h2>Full Job Description</h2>
+              <p>Position Description:</p>
+              <p>MUST HAVE PREVIOUS EXPERIENCE!!!!</p>
+              <p>Responsibilities:</p>
+              <p>Answer and direct phone calls</p>
+            </section>
+          </main>
+          <aside>
+            <h2>Our Most Similar Jobs</h2>
+            <a>Office Assistant</a>
+            <p>A-OK Portable Services</p>
+          </aside>
+          <script type="application/ld+json">
+            {
+              "@context": "https://schema.org",
+              "@type": "JobPosting",
+              "title": "Administrative Assistant",
+              "description": "<p>Position Description:</p><p>MUST HAVE PREVIOUS EXPERIENCE!!!!</p><p>Responsibilities:</p><p>Answer and direct phone calls</p>",
+              "datePosted": "2026-06-30T01:52:48.992Z",
+              "employmentType": "FULL_TIME",
+              "hiringOrganization": {"name": "CERTITEMP OF GEORGIA LLC"},
+              "jobLocation": {
+                "@type": "Place",
+                "address": {
+                  "@type": "PostalAddress",
+                  "addressLocality": "Macon",
+                  "addressRegion": "GA",
+                  "addressCountry": "US"
+                }
+              },
+              "baseSalary": {
+                "@type": "MonetaryAmount",
+                "currency": "USD",
+                "value": {
+                  "@type": "QuantitativeValue",
+                  "minValue": 22.58,
+                  "maxValue": 27.19,
+                  "unitText": "HOUR"
+                }
+              }
+            }
+          </script>
+        </body>
+      </html>
+    `;
+
+    const detail = service.parseDetailHtml(html, DescriptionFormat.PLAIN);
+
+    expect(detail.title).toBe('Administrative Assistant');
+    expect(detail.companyName).toBe('CERTITEMP OF GEORGIA LLC');
+    expect(detail.location.city).toBe('Macon');
+    expect(detail.location.state).toBe('GA');
+    expect(detail.description).toContain('Position Description');
+    expect(detail.description).toContain('Answer and direct phone calls');
+    expect(detail.description).not.toContain('Our Most Similar Jobs');
+    expect(detail.description).not.toContain('A-OK Portable Services');
+    expect(detail.compensation.minAmount).toBe(22.58);
+    expect(detail.compensation.maxAmount).toBe(27.19);
+    expect(detail.employmentType).toBe('FULL_TIME');
+    expect(detail.skills).toEqual([
+      'Administrative experience',
+      'Productivity software',
+    ]);
+  });
+
+  it('rejects CSS fragments as descriptions', () => {
+    expect(service.usefulDescription('.css-lvyu5j{margin-right:10px;}Macon, GA')).toBeNull();
+  });
+});

--- a/packages/plugins/source-simplyhired/src/simplyhired.service.ts
+++ b/packages/plugins/source-simplyhired/src/simplyhired.service.ts
@@ -11,11 +11,18 @@ import {
   JobPostDto,
   LocationDto,
   Site,
+  DescriptionFormat,
+  getJobTypeFromString,
 } from '@ever-jobs/models';
 import {
   createHttpClient,
   randomSleep,
   extractSalary,
+  extractEmails,
+  htmlToPlainText,
+  markdownConverter,
+  parseJobPostingLd,
+  jobPostingLdToCompensation,
 } from '@ever-jobs/common';
 import { BrowserPool } from '@ever-jobs/common';
 import {
@@ -71,7 +78,11 @@ export class SimplyHiredService implements IScraper, OnModuleDestroy {
         const response = await client.get<string>(url.toString());
         const html = response.data;
 
-        const jobs = this.parseHtml(html);
+        const jobs = await this.enrichJobDetails(
+          client,
+          this.parseHtml(html),
+          input.descriptionFormat,
+        );
         if (jobs.length === 0) break;
 
         allJobs.push(...jobs);
@@ -113,7 +124,13 @@ export class SimplyHiredService implements IScraper, OnModuleDestroy {
       await this.delay(5000);
 
       const html = await page.content();
-      const jobs = this.parseHtml(html);
+      const client = createHttpClient(input);
+      client.setHeaders(SIMPLYHIRED_HEADERS);
+      const jobs = await this.enrichJobDetails(
+        client,
+        this.parseHtml(html),
+        input.descriptionFormat,
+      );
 
       if (jobs.length === 0) {
         // TODO: Validate selectors against live SimplyHired rendered DOM
@@ -182,7 +199,9 @@ export class SimplyHiredService implements IScraper, OnModuleDestroy {
         const company = card.find('[data-testid="companyName"], .jobposting-company, .SerpJob-link--company').text().trim() || null;
         const location = card.find('[data-testid="searchSerpJobLocation"], .jobposting-location, .SerpJob-location').text().trim() || null;
         const salaryText = card.find('[data-testid="searchSerpJobSalaryEst"], .jobposting-salary, .SerpJob-salary').text().trim() || null;
-        const snippet = card.find('.jobposting-snippet, .SerpJob-snippet, p').first().text().trim() || null;
+        const snippet = this.usefulDescription(
+          card.find('.jobposting-snippet, .SerpJob-snippet, p').first().text().trim(),
+        );
 
         let compensation = null;
         if (salaryText) {
@@ -215,6 +234,222 @@ export class SimplyHiredService implements IScraper, OnModuleDestroy {
     });
 
     return jobs;
+  }
+
+  private async enrichJobDetails(
+    client: ReturnType<typeof createHttpClient>,
+    jobs: JobPostDto[],
+    format: DescriptionFormat | undefined,
+  ): Promise<JobPostDto[]> {
+    const enriched: JobPostDto[] = [];
+
+    for (const job of jobs) {
+      try {
+        const response = await client.get<string>(job.jobUrl);
+        const detail = this.parseDetailHtml(response.data ?? '', format);
+        enriched.push(new JobPostDto({
+          ...job,
+          title: detail.title ?? job.title,
+          companyName: detail.companyName ?? job.companyName,
+          location: detail.location ?? job.location,
+          description: detail.description ?? job.description ?? null,
+          compensation: detail.compensation ?? job.compensation ?? null,
+          datePosted: detail.datePosted ?? job.datePosted ?? null,
+          employmentType: detail.employmentType ?? job.employmentType ?? null,
+          jobType: detail.jobType ?? job.jobType ?? null,
+          skills: detail.skills ?? job.skills ?? null,
+          isRemote: detail.isRemote ?? job.isRemote ?? null,
+          applyUrl: detail.applyUrl ?? job.applyUrl ?? job.jobUrl,
+          companyLogo: detail.companyLogo ?? job.companyLogo ?? null,
+          emails: extractEmails(detail.description ?? job.description ?? ''),
+        }));
+      } catch (err: any) {
+        this.logger.warn(`SimplyHired detail fetch failed for ${job.jobUrl}: ${err.message}`);
+        enriched.push(job);
+      }
+    }
+
+    return enriched;
+  }
+
+  private parseDetailHtml(
+    html: string,
+    format: DescriptionFormat | undefined,
+  ): Partial<JobPostDto> {
+    const $ = cheerio.load(html);
+    const posting = parseJobPostingLd(html)[0] ?? null;
+    const main = this.mainJobHtml($);
+    const mainText = this.cleanText(htmlToPlainText(main || $('body').html() || html));
+
+    const descriptionRaw =
+      posting?.description ??
+      this.extractFullDescriptionHtml($) ??
+      this.extractFullDescriptionText(mainText);
+    const description = this.formatDescription(descriptionRaw, format);
+
+    const compensation =
+      jobPostingLdToCompensation(posting?.baseSalary) ??
+      this.compensationFromText(mainText);
+
+    const employmentType =
+      posting?.employmentType ??
+      this.firstMatchingLine(mainText, /\b(full[- ]?time|part[- ]?time|contract|temporary|internship)\b/i);
+    const jobType = employmentType
+      ? [getJobTypeFromString(employmentType)].filter((t): t is NonNullable<typeof t> => !!t)
+      : null;
+
+    const skills = this.extractChips($, 'Qualifications');
+    const location = this.locationFromPosting(posting) ?? this.locationFromText(mainText);
+
+    return {
+      title: posting?.title ?? ($('h1').first().text().trim() || undefined),
+      companyName: posting?.hiringOrganizationName ?? this.companyFromText(mainText),
+      location,
+      description,
+      compensation,
+      datePosted: posting?.datePosted ?? null,
+      employmentType,
+      jobType: jobType && jobType.length > 0 ? jobType : null,
+      skills: skills.length > 0 ? skills : null,
+      isRemote: posting?.remote ?? /\bremote\b/i.test(mainText),
+      applyUrl: posting?.applyUrl ?? posting?.url ?? null,
+      companyUrl: posting?.hiringOrganizationUrl ?? null,
+    };
+  }
+
+  private mainJobHtml($: cheerio.CheerioAPI): string {
+    $('aside, nav, header, footer, script, style').remove();
+    $('[aria-label], [class], [data-testid]').each((_, el) => {
+      const node = $(el);
+      const marker = [
+        node.attr('aria-label'),
+        node.attr('class'),
+        node.attr('data-testid'),
+      ].join(' ').toLowerCase();
+      if (marker.includes('similar')) node.remove();
+    });
+
+    const bodyHtml = $('body').html() ?? '';
+    const cut = bodyHtml.search(/Our Most Similar Jobs|View more similar jobs|latest job alert/i);
+    return cut >= 0 ? bodyHtml.slice(0, cut) : bodyHtml;
+  }
+
+  private extractFullDescriptionHtml($: cheerio.CheerioAPI): string | null {
+    const headings = $('h2, h3, h4')
+      .filter((_, el) => /full job description|position description|job description/i.test($(el).text()))
+      .toArray();
+    const heading = headings[0];
+    if (!heading) return null;
+
+    const parts: string[] = [];
+    let node = $(heading).next();
+    while (node.length > 0) {
+      if (/^(h2|h3|h4)$/i.test((node.get(0) as any)?.name ?? '')) break;
+      const html = node.html();
+      if (html) parts.push(html);
+      node = node.next();
+    }
+    return parts.length > 0 ? parts.join('\n') : null;
+  }
+
+  private extractFullDescriptionText(text: string): string | null {
+    const match = text.match(/(?:Full Job Description|Position Description|Job Description)\s*([\s\S]+)/i);
+    if (!match?.[1]) return null;
+    return this.cleanText(match[1].replace(/Our Most Similar Jobs[\s\S]*$/i, ''));
+  }
+
+  private formatDescription(
+    raw: string | null | undefined,
+    format: DescriptionFormat | undefined,
+  ): string | null {
+    const useful = this.usefulDescription(raw);
+    if (!useful) return null;
+    if (format === DescriptionFormat.HTML) return raw ?? null;
+    if (/<[a-z][\s\S]*>/i.test(useful)) {
+      return format === DescriptionFormat.MARKDOWN
+        ? markdownConverter(useful) ?? htmlToPlainText(useful)
+        : htmlToPlainText(useful);
+    }
+    return useful;
+  }
+
+  private extractChips($: cheerio.CheerioAPI, heading: string): string[] {
+    const head = $('h2, h3, h4')
+      .filter((_, el) => $(el).text().trim().toLowerCase() === heading.toLowerCase())
+      .first();
+    if (!head.length) return [];
+
+    const section = head.nextUntil('h2, h3, h4');
+    const values = new Set<string>();
+    section.each((_, el) => {
+      const text = this.cleanText($(el).text());
+      if (text && text.length <= 80) values.add(text);
+    });
+    section.find('li, span').each((_, el) => {
+      const text = this.cleanText($(el).text());
+      if (text && text.length <= 80) values.add(text);
+    });
+    return [...values];
+  }
+
+  private compensationFromText(text: string): JobPostDto['compensation'] {
+    const line = this.firstMatchingLine(text, /([$€£]\s?\d|salary|an hour|a year|per hour|per year)/i);
+    if (!line) return null;
+    const parsed = extractSalary(line);
+    if (parsed.minAmount == null && parsed.maxAmount == null) return null;
+    return {
+      interval: parsed.interval,
+      minAmount: parsed.minAmount,
+      maxAmount: parsed.maxAmount,
+      currency: parsed.currency ?? 'USD',
+    } as any;
+  }
+
+  private locationFromPosting(posting: ReturnType<typeof parseJobPostingLd>[number] | null): LocationDto | null {
+    const loc = posting?.locations?.[0];
+    if (!loc) return null;
+    return new LocationDto({
+      city: loc.city,
+      state: loc.region,
+      country: loc.country,
+    });
+  }
+
+  private locationFromText(text: string): LocationDto | null {
+    const line = this.firstMatchingLine(text, /\b[A-Z][a-zA-Z .'-]+,\s?[A-Z]{2}\b/);
+    if (!line) return null;
+    const match = line.match(/\b([A-Z][a-zA-Z .'-]+),\s?([A-Z]{2})\b/);
+    if (!match) return null;
+    return new LocationDto({ city: match[1].trim(), state: match[2].trim() });
+  }
+
+  private companyFromText(text: string): string | null {
+    const lines = text.split('\n').map((l) => this.cleanText(l)).filter(Boolean);
+    return lines.find((line) => line.length > 2 && line.length < 90 && !/job details|benefits|qualifications/i.test(line)) ?? null;
+  }
+
+  private firstMatchingLine(text: string, pattern: RegExp): string | null {
+    return text
+      .split('\n')
+      .map((line) => this.cleanText(line))
+      .find((line) => pattern.test(line)) ?? null;
+  }
+
+  private usefulDescription(value: string | null | undefined): string | null {
+    const text = this.cleanText(value ?? '');
+    if (!text) return null;
+    if (/\.css-[a-z0-9_-]+|--chakra-|white-space\s*:|margin-right\s*:/i.test(text)) return null;
+    if (text.length < 80) return null;
+    return text;
+  }
+
+  private cleanText(value: string): string {
+    return value
+      .replace(/\r/g, '\n')
+      .replace(/[ \t]+\n/g, '\n')
+      .replace(/\n{3,}/g, '\n\n')
+      .replace(/[ \t]{2,}/g, ' ')
+      .trim();
   }
 
   async onModuleDestroy(): Promise<void> {


### PR DESCRIPTION
## Summary
- fetch SimplyHired detail pages instead of treating SERP snippets as full descriptions
- prefer JobPosting JSON-LD for title, company, location, compensation, employment type, apply URL, and description
- reject CSS fragments as descriptions and ignore Similar Jobs sidebar content
- make GHCR image tags repository-owner neutral for fork/mirror builds
- add Gitea workflow to mirror branches/tags to fgrosswig/ever-jobs via GITHUBPAT

## Tests
- npx tsc -p packages/plugins/source-simplyhired/tsconfig.json --noEmit
- npx jest packages/plugins/source-simplyhired/__tests__/simplyhired.service.spec.ts --runInBand