### PR TITLE
fix(source-internshala): register plugin and fetch full job descriptions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -444,6 +444,7 @@
       "resolved": "https://registry.npmjs.org/@apollo/server/-/server-5.5.1.tgz",
       "integrity": "sha512-Rn3g5TJQsMSUY23CWZTghWdBWyjX7dP1eaEBPkvmM2RHi82cDcpgTIkSCbGvtTUEGjwopLv1AAooU/n7iIZ20A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@apollo/cache-control-types": "^1.0.3",
         "@apollo/server-gateway-interface": "^2.0.0",
@@ -710,6 +711,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -2905,6 +2907,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.27.tgz",
       "integrity": "sha512-kEGSzqM2lWr4whh4Ubflw+oPZSEzxvRMu9WL+LveZploJWTjec5bBlCiRVlVzTPg2kIwBiLwWSvCCW7Wnin1gg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "file-type": "21.3.4",
         "iterare": "1.2.1",
@@ -2963,6 +2966,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.1.27.tgz",
       "integrity": "sha512-K6DX7hcqmZdeXkv7tsPakKBRCgqL19a4mtbX4FluY0hWtFdtPKp6lbe+lb8gWPfvLdbOWr/CPScn7BSjBX+Ecg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-safe-stringify": "2.1.1",
         "iterare": "1.2.1",
@@ -3002,6 +3006,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/graphql/-/graphql-13.4.2.tgz",
       "integrity": "sha512-MIaMIaV9o3Tj2LsoGGwhISTZVXEIfDK8rDXplE3tSYULj6cXSY1dofOSLMF/aY+BZLwlrN4BUUowgu8qNdDZFg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@graphql-tools/merge": "9.1.9",
         "@graphql-tools/schema": "10.0.33",
@@ -3067,6 +3072,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.27.tgz",
       "integrity": "sha512-0ZFhz6H6EdGh4xQVbUNwjoAwBuz73P7FvUAl67h9CTdMqQlJDaQYJApBv8pKfVZ1fGjMCbl0m9DcC6pXaZPWSQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cors": "2.8.6",
         "express": "5.2.1",
@@ -3489,6 +3495,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3533,6 +3540,7 @@
       "integrity": "sha512-mKq3jQFhjvko5LTJFHGilsuQs+W+T3Gm451NzuTDGQxwCzwXHYnIu2zGkRoW+Exq3Rob7yp2MfzSrdIiZVhrBg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=18.18"
       },
@@ -3960,6 +3968,7 @@
       "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -4305,7 +4314,6 @@
       "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.33.tgz",
       "integrity": "sha512-HsJ+z3QuETzP3cswwtzt2vEIiHBk/dCcHGhbmG5X3ecnwFD/lPrMpliGXxSCg03L9AhrdwA4Oz/qfspkDW+xGQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -4387,6 +4395,7 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -4818,29 +4827,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -5223,6 +5209,7 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5280,6 +5267,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -5990,6 +5978,7 @@
       "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
@@ -6109,6 +6098,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.38",
         "caniuse-lite": "^1.0.30001799",
@@ -6273,6 +6263,7 @@
       "resolved": "https://registry.npmjs.org/cache-manager/-/cache-manager-7.2.8.tgz",
       "integrity": "sha512-0HDaDLBBY/maa/LmUVAr70XUOwsiQD+jyzCBjmUErYZUKdMS9dT59PqW59PpVqfGM7ve6H0J6307JTpkCYefHQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cacheable/utils": "^2.3.3",
         "keyv": "^5.5.5"
@@ -6526,13 +6517,15 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/class-validator": {
       "version": "0.14.4",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.4.tgz",
       "integrity": "sha512-AwNusCCam51q703dW82x95tOqQp6oC9HNUl724KxJJOfnKscI8dOloXFgyez7LbTTKWuRBA37FScqVbJEoq8Yw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -7882,6 +7875,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -8252,6 +8246,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -9383,6 +9378,7 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
       "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -9582,6 +9578,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
       "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -10156,6 +10153,7 @@
       "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.4.2",
         "@jest/types": "30.4.1",
@@ -10922,6 +10920,7 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -11555,6 +11554,7 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
       "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16"
       }
@@ -12599,6 +12599,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/config": "6.19.3",
         "@prisma/engines": "6.19.3"
@@ -12984,7 +12985,8 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/request": {
       "version": "2.88.2",
@@ -13250,6 +13252,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -13305,6 +13308,7 @@
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -15218,6 +15222,7 @@
       "integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -15507,6 +15512,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -15705,6 +15711,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/packages/plugins/index.ts
+++ b/packages/plugins/index.ts
@@ -420,6 +420,7 @@ import { HimalayasModule } from './source-himalayas';
 import { IcrunchdataModule } from './source-icrunchdata';
 import { IndeedModule } from './source-indeed';
 import { InfoJobsModule } from './source-infojobs';
+import { InternshalaModule } from './source-internshala';
 import { IosdevjobsModule } from './source-iosdevjobs';
 import { JobDataApiModule } from './source-jobdataapi';
 import { JsonLdModule } from './source-jsonld';
@@ -2229,6 +2230,7 @@ export const ALL_SOURCE_MODULES = [
   IcrunchdataModule,
   IndeedModule,
   InfoJobsModule,
+  InternshalaModule,
   IosdevjobsModule,
   JobDataApiModule,
   JobicyModule,

--- a/packages/plugins/source-internshala/src/internshala.service.ts
+++ b/packages/plugins/source-internshala/src/internshala.service.ts
@@ -7,7 +7,7 @@ import {
   LocationDto, DescriptionFormat, Site,
 } from '@ever-jobs/models';
 import {
-  createHttpClient, markdownConverter, plainConverter, randomSleep, extractEmails,
+  HttpClient, createHttpClient, markdownConverter, plainConverter, randomSleep, extractEmails,
 } from '@ever-jobs/common';
 
 /** Internshala base URLs and selectors */
@@ -82,8 +82,41 @@ export class InternshalaService implements IScraper {
       this.logger.error(`Internshala scrape error: ${err.message}`);
     }
 
+    // Listing cards never carry the real job description (only stipend/duration/
+    // apply-by snippets) — fetch each job's own detail page for the full body.
+    for (const job of jobList) {
+      try {
+        const fullDescription = await this.fetchDescription(client, job.jobUrl, input.descriptionFormat);
+        if (fullDescription) {
+          job.description = job.description ? `${fullDescription}\n\n${job.description}` : fullDescription;
+          job.emails = extractEmails(job.description) ?? job.emails;
+        }
+      } catch (err: any) {
+        this.logger.warn(`Error fetching description for ${job.jobUrl}: ${err.message}`);
+      }
+      await randomSleep(this.delay * 1000, (this.delay + this.bandDelay) * 1000);
+    }
+
     this.logger.log(`Internshala: found ${jobList.length} jobs/internships`);
     return new JobResponseDto(jobList);
+  }
+
+  private async fetchDescription(
+    client: HttpClient,
+    jobUrl: string,
+    format?: DescriptionFormat,
+  ): Promise<string | null> {
+    const resp = await client.get(jobUrl);
+    const $ = cheerio.load(resp.data);
+
+    const el = $('.internship_details .text-container, .detail_view').first();
+    if (!el.length) return null;
+
+    const html = el.html() ?? '';
+    if (format === DescriptionFormat.PLAIN) {
+      return plainConverter(html);
+    }
+    return markdownConverter(html);
   }
 
   private buildSearchUrl(searchTerm: string, input: ScraperInputDto, page: number): string {
@@ -120,9 +153,13 @@ export class InternshalaService implements IScraper {
       || $card.find('a').first().text().trim();
     if (!title) return null;
 
-    // Extract company
-    const companyName = $card.find('.company-name, .company_name, .link_display_like_text').first().text().trim()
-      || $card.find('p.company-name a').text().trim();
+    // Extract company. `.company-name` (the inner <p>) holds just the clean name;
+    // the wrapping `.company_name` div also matches an "Actively hiring" badge
+    // as a child, so it must only be a fallback, never tried first.
+    let companyEl = $card.find('.company-name').first();
+    if (!companyEl.length) companyEl = $card.find('.company_name, .link_display_like_text').first();
+    companyEl.find('.actively-hiring-badge').remove();
+    const companyName = companyEl.text().trim() || $card.find('p.company-name a').text().trim();
 
     // Extract URL
     let jobUrl = $card.find('a.job-title-href, a.view_detail_button, h3 a, a').first().attr('href') ?? '';
@@ -135,8 +172,8 @@ export class InternshalaService implements IScraper {
     const id = `is-${urlHash}`;
 
     // Extract location
-    const locationText = $card.find('.location_link, .individual_location_name, .ic-16-map-marker + span, #location_names span').first().text().trim()
-      || $card.find('.locations').text().trim();
+    const locationText = ($card.find('.location_link, .individual_location_name, .ic-16-map-marker + span, #location_names span').first().text().trim()
+      || $card.find('.locations').text().trim()).replace(/\s+/g, ' ').trim();
 
     const location = new LocationDto({
       city: locationText || undefined,


### PR DESCRIPTION
## Summary

Internshala (`siteType: ["internshala"]`) was effectively unusable: requests
failed outright with "Unknown site: internshala", and once that's fixed, every
result's `description` field contained only a stipend line instead of the
actual job description. This PR fixes both, plus two smaller data-quality
bugs found while tracing the description issue.

## Problem

1. **Plugin never registered.** `packages/plugins/source-internshala/` shipped
   a complete package (module, service, tests) with its `tsconfig.base.json`
   path and `jest.config.js` moduleNameMapper entries already in place — but
   it was never imported into `packages/plugins/index.ts`'s
   `ALL_SOURCE_MODULES` array. `PluginRegistry` never discovered it, so any
   request with `siteType: ["internshala"]` logged `WARN Unknown site:
   internshala` and silently skipped the source.

2. **`description` only ever contained the stipend.** The listing page
   (`internshala.com/jobs/...`) cards never carry the full job description —
   only stipend/duration/apply-by snippets. The plugin's description selector
   (`.job-description-text, .detail_view`) was written for the job's own
   *detail* page, but nothing ever fetched that page, so `description` fell
   back to just `"Stipend: ₹ X - Y"` for every result. Confirmed by fetching a
   live detail page directly — the real content lives at
   `div.internship_details .text-container`.

3. **`companyName` had a badge glued onto it**, e.g.
   `"EMIAC Technologies                        Actively hiring"`. The
   selector's `.first()` matched the outer `.company_name` wrapper div
   (which contains an `"Actively hiring"` badge as a child) before the inner,
   more specific `p.company-name` that holds just the clean text.

4. **`location.city` carried raw HTML whitespace/newlines through** for
   multi-location and hybrid listings, e.g.
   `"Mumbai                                                                    (Hybrid)"`.

## Fix

- Registered `InternshalaModule` in `packages/plugins/index.ts` (both the
  import and the `ALL_SOURCE_MODULES` array entry).
- Added a per-job detail-page fetch (`fetchDescription()`, same pattern as
  the LinkedIn plugin's `linkedinFetchDescription` path) that pulls the real
  "About the job" body from `div.internship_details .text-container` and
  prepends it to the existing stipend/duration/apply-by line, so no
  information is lost.
- Reordered the company-name selector to try the specific `.company-name`
  element first, and strip any `.actively-hiring-badge` defensively.
- Collapsed internal whitespace on the extracted location string.

## Testing

- `npx tsc --project tsconfig.base.json --noEmit` — clean.
- `packages/plugins/source-internshala/__tests__/internshala.e2e-spec.ts` —
  passes against the live site (49s).
- `npx jest --forceExit` (full suite) run per the contributing guide.

## Notes

- The description fetch adds one extra HTTP request per job (bounded by
  `resultsWanted`, same cost model as LinkedIn's optional description fetch).
  Internshala isn't behind Cloudflare/reCAPTCHA like some other sources, so
  this is always-on rather than gated behind a flag — `description` is a
  required field for consumers of this API.
