### PR TITLE
ci: route runners to self-hosted ARC pools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   docs-lint:
     name: Docs Lint
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     steps:
       - name: Checkout
@@ -32,7 +32,7 @@ jobs:
 
   build:
     name: Build & Type-Check
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     strategy:
       matrix:
@@ -67,7 +67,7 @@ jobs:
 
   test-fast:
     name: Test (Health & Smoke)
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
     needs: build
 
     steps:
@@ -88,7 +88,7 @@ jobs:
 
   test-e2e:
     name: Test (E2E - Live APIs)
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
     needs: build
     continue-on-error: true
 
@@ -115,7 +115,7 @@ jobs:
 
   test-sources:
     name: Test (Source Scrapers)
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
     needs: build
     continue-on-error: true
 
@@ -139,7 +139,7 @@ jobs:
 
   test-feature-plugins:
     name: Test (Feature Plugins)
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
     needs: build
 
     steps:
@@ -168,7 +168,7 @@ jobs:
 
   docker:
     name: Docker Build
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
     needs: build
 
     steps:

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -55,7 +55,7 @@ jobs:
           cache-to: type=inline
 
   build-mcp:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7


### PR DESCRIPTION
Repoints every GitHub-hosted `ubuntu-latest` runner in this repo's workflows onto our self-hosted ARC pools (org vars `RUNNER_LINUX_X64_{4,8}`, with `|| 'ubuntu-latest'` fallback so forks/PRs without the vars still run). This unblocks/keeps CI on our self-hosted-only runner policy.

**`.github/workflows/ci.yml`**
- `docs-lint`, `build` (Build & Type-Check), `test-fast`, `test-sources`, `test-feature-plugins`: `ubuntu-latest` → `RUNNER_LINUX_X64_4` (light lint/typecheck/test jobs).
- `test-e2e` (E2E live APIs), `docker` (Docker image build): `ubuntu-latest` → `RUNNER_LINUX_X64_8` (heavy).

**`.github/workflows/docker-build-publish.yml`**
- `build`, `build-mcp` (GHCR docker build+push): `ubuntu-latest` → `RUNNER_LINUX_X64_8` (heavy).

Only `runs-on:` values changed — no other edits. 🤖 Generated with [Claude Code](https://claude.com/claude-code)