### PR TITLE
Promote stage → main: cooperative dedup + :latest from main only

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -58,11 +58,19 @@ jobs:
           file: ./Dockerfile
           push: true
           platforms: linux/amd64
+          # `:latest` tracks PRODUCTION only.
+          # It used to be pushed from EVERY branch, so it floated to whichever
+          # environment happened to build last — a dev build would silently
+          # claim `:latest`. Nothing on ever-k8s consumes it (all three envs pin
+          # :dev/:stage/:prod, resolved to a digest by ArgoCD Image Updater), but
+          # a floating `:latest` is how mcpserver.ever.works ended up serving a
+          # six-week-old dev image for weeks.
           tags: |
-            ghcr.io/ever-jobs/ever-jobs:latest
             ghcr.io/ever-jobs/ever-jobs:${{ steps.envtag.outputs.tag }}
             ghcr.io/ever-jobs/ever-jobs:${{ github.sha }}
-          cache-from: type=registry,ref=ghcr.io/ever-jobs/ever-jobs:latest
+            ${{ github.ref_name == 'main' && 'ghcr.io/ever-jobs/ever-jobs:latest' || '' }}
+          # Warm from THIS environment's own tag, not the floating `:latest`.
+          cache-from: type=registry,ref=ghcr.io/ever-jobs/ever-jobs:${{ steps.envtag.outputs.tag }}
           cache-to: type=inline
 
   build-mcp:
@@ -95,9 +103,11 @@ jobs:
           file: ./.deploy/mcp/Dockerfile
           push: true
           platforms: linux/amd64
+          # `:latest` tracks PRODUCTION only — see the note on the API image above.
           tags: |
-            ghcr.io/ever-jobs/ever-jobs-mcp:latest
             ghcr.io/ever-jobs/ever-jobs-mcp:${{ steps.envtag.outputs.tag }}
             ghcr.io/ever-jobs/ever-jobs-mcp:${{ github.sha }}
-          cache-from: type=registry,ref=ghcr.io/ever-jobs/ever-jobs-mcp:latest
+            ${{ github.ref_name == 'main' && 'ghcr.io/ever-jobs/ever-jobs-mcp:latest' || '' }}
+          # Warm from THIS environment's own tag, not the floating `:latest`.
+          cache-from: type=registry,ref=ghcr.io/ever-jobs/ever-jobs-mcp:${{ steps.envtag.outputs.tag }}
           cache-to: type=inline

--- a/packages/plugins/dedup-hybrid/__tests__/dedup-event-loop.spec.ts
+++ b/packages/plugins/dedup-hybrid/__tests__/dedup-event-loop.spec.ts
@@ -1,0 +1,295 @@
+import { JobPostDto, LocationDto, Site } from "@ever-jobs/models";
+import { DedupHybridService } from "../src/dedup-hybrid.service";
+import { MinHashStrategy } from "../src/strategies/minhash-strategy";
+import { PreparedJob } from "../src/types";
+
+/**
+ * Event-loop liveness gate.
+ *
+ * Production symptom this guards: `dedup()` is `async` but used to hold the
+ * thread for the whole pass (a ~6 900-job search reported
+ * `dedup_metrics.elapsedMs = 10604`). `GET /health` is a pure in-process
+ * handler, so a blocked loop is the only thing that can make it time out —
+ * and the liveness probe (period 20 s, timeout 15 s, failureThreshold 6) then
+ * SIGKILLs the container.
+ *
+ * The probe simulated here is a self-rescheduling `setImmediate` chain, which
+ * is exactly what an inbound HTTP request needs in order to be served: the
+ * poll phase must be reached. Microtasks (`Promise.resolve()`,
+ * `process.nextTick`) would *not* be a valid stand-in — they run without ever
+ * leaving the current turn.
+ *
+ * Without the cooperative yields the whole `dedup()` body runs synchronously
+ * inside the caller's turn, so the chain ticks **zero** times and the worst gap
+ * is the full pass — measured against the pre-fix build at this batch size:
+ * `ticks=0 worstGapMs=1331`. Both assertions below fail. With the fix:
+ * `ticks=131 worstGapMs=18`, and the pass wall-clock is unchanged
+ * (1331 ms -> 1335 ms) with a byte-identical `assignments` array.
+ */
+
+const MAX_STALL_MS = Number(process.env.DEDUP_LOOP_MAX_STALL_MS ?? 250);
+
+/** Long enough to clear `minTextLength` (80) with room to spare. */
+const DESC_TOKENS = 600;
+
+const VOCAB = (
+  "we are hiring a senior software engineer to join our backend platform team you will design build " +
+  "and operate distributed systems running on kubernetes the ideal candidate has strong experience " +
+  "with typescript nestjs and postgresql we offer competitive salary equity and a remote friendly " +
+  "work environment responsibilities include mentoring peers reviewing pull requests owning services " +
+  "in production participating in on call rotation and collaborating with product managers designers " +
+  "and data scientists across the organisation benefits include health insurance dental vision paid " +
+  "time off parental leave learning budget and a home office stipend apply today"
+).split(" ");
+
+/**
+ * Deterministic PRNG (mulberry32) so every posting gets a *distinct*,
+ * prose-shaped description. Distinctness matters: identical texts collapse to
+ * one MinHash slot (Spec 722 / FR-5), which would make the batch cheap and the
+ * test vacuous.
+ */
+function mulberry32(seed: number): () => number {
+  let s = seed >>> 0;
+  return () => {
+    s = (s + 0x6d2b79f5) >>> 0;
+    let t = s;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function description(seed: number): string {
+  const rnd = mulberry32(seed + 1);
+  const words: string[] = new Array(DESC_TOKENS);
+  for (let i = 0; i < DESC_TOKENS; i++)
+    words[i] = VOCAB[Math.floor(rnd() * VOCAB.length)];
+  return `${words.join(" ")} req-${seed}`;
+}
+
+/** Size of each near-duplicate group: one head + `CLUSTER_SPAN - 1` members. */
+const CLUSTER_SPAN = 5;
+
+/**
+ * A near-duplicate of `head`'s description: the same prose with ~4 % of its
+ * tokens swapped, which lands well inside the MinHash similarity threshold.
+ *
+ * 🛑 Load-bearing for tests 2 and 3. An earlier version of this fixture drew
+ * every token at random, so NO two postings were near-duplicates, `cluster()`
+ * returned `{clusters: []}`, and the equality/determinism assertions compared
+ * an empty partition to itself — they passed against a `clusterAsync` that
+ * unconditionally returned `{clusters: []}`. With real clusters those tests
+ * exercise the LSH pair loop and the component-emit path, which are exactly
+ * the checkpoints the cooperative pass adds. `expect(...clusters.length)` in
+ * test 2 is the guard that stops this silently regressing again.
+ */
+function nearDuplicate(headSeed: number, variant: number): string {
+  const base = description(headSeed).split(" ");
+  const rnd = mulberry32(headSeed * 1000 + variant);
+  const swaps = Math.max(1, Math.floor(base.length * 0.04));
+  for (let s = 0; s < swaps; s++) {
+    base[Math.floor(rnd() * base.length)] =
+      VOCAB[Math.floor(rnd() * VOCAB.length)];
+  }
+  return base.join(" ");
+}
+
+function buildBatch(size: number): JobPostDto[] {
+  const out: JobPostDto[] = [];
+  for (let i = 0; i < size; i++) {
+    const headSeed = i - (i % CLUSTER_SPAN);
+    const variant = i % CLUSTER_SPAN;
+    out.push(
+      new JobPostDto({
+        id: String(i),
+        title: `Engineer ${headSeed}`,
+        companyName: `Company ${headSeed}`,
+        jobUrl: `https://e.test/${i}`,
+        site: i % 2 === 0 ? Site.GREENHOUSE : Site.LINKEDIN,
+        // Heads keep a wholly distinct description so the batch stays
+        // signature-dominated (that is what makes the pass slow); members are
+        // near-duplicates of their head so real clusters actually form.
+        description:
+          variant === 0 ? description(i) : nearDuplicate(headSeed, variant),
+        location: new LocationDto({
+          city: "Remote",
+          state: "",
+          country: "USA",
+        }),
+      }),
+    );
+  }
+  return out;
+}
+
+function preparedFrom(jobs: ReadonlyArray<JobPostDto>): PreparedJob[] {
+  return jobs.map((raw, index) => ({
+    index,
+    canonicalKey: `key-${index}`,
+    canonicalJobId: `id-${index}`,
+    raw,
+  }));
+}
+
+/**
+ * Stand-in for the liveness probe: a `setImmediate` chain that records the
+ * worst gap between consecutive visits to the check phase. Returns a stopper
+ * that yields the observations.
+ */
+function startEventLoopProbe(): () => { ticks: number; worstGapMs: number } {
+  let ticks = 0;
+  let worstGapMs = 0;
+  let lastRunAt = Date.now();
+  let running = true;
+
+  const schedule = (): void => {
+    setImmediate(() => {
+      const now = Date.now();
+      const gap = now - lastRunAt;
+      if (gap > worstGapMs) worstGapMs = gap;
+      lastRunAt = now;
+      ticks++;
+      if (running) schedule();
+    });
+  };
+  schedule();
+
+  return () => {
+    running = false;
+    // Fold in the still-open gap. A loop that was starved for the whole pass
+    // records *no* ticks, and without this it would report a worst gap of 0 —
+    // the total-starvation case has to be the worst reading, not the best.
+    const trailing = Date.now() - lastRunAt;
+    if (trailing > worstGapMs) worstGapMs = trailing;
+    return { ticks, worstGapMs };
+  };
+}
+
+describe("dedup — event-loop liveness", () => {
+  it(`answers the event loop within ${MAX_STALL_MS} ms while deduping a large batch`, async () => {
+    const batch = buildBatch(2500);
+    const service = new DedupHybridService();
+
+    const stopProbe = startEventLoopProbe();
+    const started = Date.now();
+    const out = await service.dedup(batch);
+    const elapsed = Date.now() - started;
+    const { ticks, worstGapMs } = stopProbe();
+
+    // Guard: the pass has to be long enough for the assertion to mean
+    // something. If this trips, the batch got cheap — grow it, don't relax it.
+    expect(elapsed).toBeGreaterThan(300);
+    expect(out.metrics.inputCount).toBe(batch.length);
+
+    // The loop actually got serviced *during* the pass. Unyielded, the whole
+    // `dedup()` body runs inside the caller's turn and this is 0.
+    expect(ticks).toBeGreaterThan(10);
+
+    // No single slice may hold the thread long enough to threaten the probe.
+    // Unyielded this equals the whole pass (~1 400 ms locally at this batch
+    // size; 10 604 ms on the production batch that prompted the fix).
+    expect(worstGapMs).toBeLessThan(MAX_STALL_MS);
+  }, 120_000);
+
+  it("clusterAsync returns exactly the partition the synchronous cluster() returns", async () => {
+    // The cooperative path must be a scheduling change only. Same strategy
+    // instance, same input, both entry points — byte-identical partitions.
+    const input = preparedFrom(buildBatch(400));
+    const strategy = new MinHashStrategy();
+
+    const sync = strategy.cluster(input);
+    const cooperative = await strategy.clusterAsync(input);
+
+    // 🛑 ANTI-VACUITY GUARD — assert BEFORE the equality, or this test is
+    // worthless. With a fixture of wholly-distinct descriptions both sides are
+    // `{clusters: []}` and the comparison passes against a `clusterAsync` that
+    // returns a hard-coded empty partition (verified by mutation). Real
+    // clusters are what force the LSH pair loop and the component-emit path —
+    // the two checkpoints nothing else in the suite reaches.
+    expect(sync.clusters.length).toBeGreaterThan(10);
+    expect(sync.clusters.some((c) => c.length >= 2)).toBe(true);
+
+    expect(JSON.stringify(cooperative)).toEqual(JSON.stringify(sync));
+  }, 60_000);
+
+  it("serialises concurrent passes so only one working set is ever resident", async () => {
+    // The yields removed the accidental mutual exclusion a fully synchronous
+    // pass used to provide, so dedup() gates itself. Without the gate K
+    // concurrent passes hold K working sets (slots, buckets, signatures) live
+    // at once - measured +67% peak heap at K=8 - which is the wrong trade for a
+    // service that has aborted with "Reached heap limit".
+    //
+    // Counting callers of dedup() would prove nothing: they all enter, then
+    // queue. What matters is concurrent occupancy of the CLUSTERING pass, which
+    // is what actually holds the memory, so that is what this counts.
+    const realClusterAsync = MinHashStrategy.prototype.clusterAsync;
+    let inside = 0;
+    let maxInside = 0;
+    const spy = jest
+      .spyOn(MinHashStrategy.prototype, "clusterAsync")
+      .mockImplementation(async function (
+        this: MinHashStrategy,
+        input: ReadonlyArray<PreparedJob>,
+      ) {
+        inside++;
+        if (inside > maxInside) maxInside = inside;
+        try {
+          return await realClusterAsync.call(this, input);
+        } finally {
+          inside--;
+        }
+      });
+
+    try {
+      const service = new DedupHybridService();
+      const batch = buildBatch(200);
+      await Promise.all([
+        service.dedup(batch),
+        service.dedup(batch),
+        service.dedup(batch),
+        service.dedup(batch),
+      ]);
+
+      // 4 without the gate, 1 with it.
+      expect(maxInside).toBe(1);
+    } finally {
+      spy.mockRestore();
+    }
+  }, 120_000);
+
+  it("a failing pass does not wedge the queue for later callers", async () => {
+    // The gate is a promise chain; if a rejected link were awaited unguarded,
+    // one bad batch would deadlock every later search for the pod's lifetime.
+    const service = new DedupHybridService();
+
+    await expect(
+      service.dedup(undefined as unknown as ReadonlyArray<JobPostDto>),
+    ).rejects.toBeDefined();
+
+    const after = await service.dedup(buildBatch(20));
+    expect(after.metrics.inputCount).toBe(20);
+  }, 60_000);
+
+  it("a cooperative pass is still deterministic when interleaved with another", async () => {
+    // Two dedup() calls in flight over the same singleton service: their
+    // yields interleave, so this fails if the pipeline kept any per-call state
+    // on the instance.
+    const service = new DedupHybridService();
+    const batch = buildBatch(300);
+
+    const solo = await service.dedup(batch);
+    const [a, b] = await Promise.all([
+      service.dedup(batch),
+      service.dedup(batch),
+    ]);
+
+    // Anti-vacuity: the batch must actually merge, or "deterministic" is
+    // trivially true for three empty results.
+    expect(solo.metrics.outputCount).toBeLessThan(batch.length);
+
+    expect(a.assignments).toEqual(solo.assignments);
+    expect(b.assignments).toEqual(solo.assignments);
+    expect(a.metrics.outputCount).toBe(solo.metrics.outputCount);
+    expect(b.metrics.outputCount).toBe(solo.metrics.outputCount);
+  }, 120_000);
+});

--- a/packages/plugins/dedup-hybrid/src/cooperative.ts
+++ b/packages/plugins/dedup-hybrid/src/cooperative.ts
@@ -1,0 +1,79 @@
+/**
+ * Cooperative-scheduling helpers for the dedup pipeline.
+ *
+ * `DedupHybridService.dedup()` is declared `async` but, before this module
+ * existed, contained no `await` between its first and last statement: a
+ * ~6 900-job production search reported `dedup_metrics.elapsedMs = 10604` —
+ * 10.6 s of uninterrupted synchronous CPU on the single thread that also
+ * answers `GET /health`. `/health` is a pure in-process handler (no I/O), so
+ * the only way it can time out is a blocked event loop; the liveness probe
+ * (period 20 s, timeout 15 s, failureThreshold 6) duly declared the container
+ * dead and Kubernetes SIGKILLed it.
+ *
+ * The fix is cooperative, not algorithmic: the long passes check a wall-clock
+ * budget and hand the loop back when it is spent. Nothing about the clustering
+ * result changes — see `MinHashStrategy.clusterAsync`.
+ *
+ * **Why `setImmediate` and not a microtask.** `await Promise.resolve()` and
+ * `process.nextTick()` drain the *microtask* queue and never leave the current
+ * loop turn, so no pending socket is ever polled — they would not have fixed
+ * anything. `setImmediate` resumes in the **check** phase, i.e. after the poll
+ * phase has delivered whatever I/O arrived, so an inbound `/health` request is
+ * served before dedup resumes. `setTimeout(fn, 0)` also leaves the turn but is
+ * clamped to >= 1 ms per hop, which would be ~100x more expensive here.
+ *
+ * **Measured cost** (Node 24, this package's hot paths):
+ *   - one `setImmediate` round-trip  ~3.1 us
+ *   - one `Date.now()`               ~0.10 us
+ * At the default 10 ms budget a 10.6 s pass yields ~1 060 times, i.e. ~3.3 ms
+ * of added latency — ~0.03 %.
+ */
+
+/**
+ * Milliseconds of uninterrupted CPU a dedup pass may hold before it must hand
+ * the event loop back.
+ *
+ * 10 ms keeps the worst-case `/health` stall three orders of magnitude under
+ * the 15 s probe timeout while costing ~0.03 % in added wall-clock. Raising it
+ * buys almost nothing (the yield itself is already only 0.03 % of the pass);
+ * lowering it below ~1 ms starts to be dominated by the `setImmediate` hop.
+ */
+export const DEFAULT_YIELD_BUDGET_MS = 10;
+
+/**
+ * Resolve on the next event-loop **check** phase — after pending I/O callbacks
+ * have run. See the module doc for why this is not a microtask.
+ */
+export function yieldToEventLoop(): Promise<void> {
+  return new Promise<void>((resolve) => {
+    setImmediate(resolve);
+  });
+}
+
+/**
+ * A wall-clock CPU budget for one pass.
+ *
+ * Prefer this over "yield every N iterations": per-iteration cost in this
+ * pipeline swings ~4x with description length (a 200-token posting signs in
+ * ~0.16 ms, an 800-token one in ~0.61 ms), and a further ~20x between the
+ * per-job loop and the per-candidate-pair loop, so any single fixed N is
+ * either far too chatty or far too coarse for half the corpus. Reading the
+ * clock costs ~0.10 us — free next to either loop's per-iteration work.
+ */
+export class YieldBudget {
+  private deadline: number;
+
+  constructor(private readonly budgetMs: number = DEFAULT_YIELD_BUDGET_MS) {
+    this.deadline = Date.now() + budgetMs;
+  }
+
+  /** `true` once the current slice has held the loop for `budgetMs`. */
+  get expired(): boolean {
+    return Date.now() >= this.deadline;
+  }
+
+  /** Open a fresh slice. Call immediately after yielding. */
+  renew(): void {
+    this.deadline = Date.now() + this.budgetMs;
+  }
+}

--- a/packages/plugins/dedup-hybrid/src/dedup-hybrid.service.ts
+++ b/packages/plugins/dedup-hybrid/src/dedup-hybrid.service.ts
@@ -13,6 +13,7 @@ import {
 } from '@ever-jobs/models';
 import { canonicalJobId, canonicalKey, normalizeCompany, normalizeLocation, normalizeTitle } from '@ever-jobs/common';
 
+import { YieldBudget, yieldToEventLoop } from './cooperative';
 import { HashStrategy } from './strategies/hash-strategy';
 import { MinHashStrategy } from './strategies/minhash-strategy';
 import { ClusterPartition, DedupHybridOptions, IDedupStrategy, PreparedJob } from './types';
@@ -34,6 +35,20 @@ import { UnionFind } from './union-find';
  *  - emits one `CanonicalJob` per cluster, picking the first observation as
  *    the field winner (replaced by `IMergeResolver` when Phase 4 lands)
  *  - returns a `DedupResult` envelope with assignments + metrics
+ *
+ * ## Cooperative scheduling
+ *
+ * Every pass below hands the event loop back once it has held it for
+ * `DEFAULT_YIELD_BUDGET_MS` (see `./cooperative`). Without that, a ~6 900-job
+ * batch is ~10.6 s of uninterrupted synchronous CPU on the same thread that
+ * serves `GET /health`, which is what made Kubernetes' liveness probe kill the
+ * pod. The yields change no output — every structure the passes touch is local
+ * to the call.
+ *
+ * 🛑 `DedupMetrics.elapsedMs` is, and remains, **wall clock**. With yields it
+ * now also counts the time the loop spent serving other requests, so under
+ * concurrency it reads *higher* than the CPU the pass actually consumed. Read
+ * it as "how long the caller waited", not "how much CPU dedup burned".
  */
 @Injectable()
 export class DedupHybridService implements IDedupEngine {
@@ -46,15 +61,72 @@ export class DedupHybridService implements IDedupEngine {
     rejectInvalid: true,
   };
 
+  /**
+   * Tail of the serialisation chain — see {@link dedup}. Never rejects: each
+   * link is resolved from a `finally`, so one failed pass cannot wedge the
+   * queue for every later caller.
+   */
+  private tail: Promise<void> = Promise.resolve();
+
+  /**
+   * Deduplicate a fan-out result. **Passes are serialised.**
+   *
+   * 🛑 The serialisation is load-bearing and exists *because* of the yields.
+   * Before them, a pass held the thread start-to-finish, so two concurrent
+   * `dedup()` calls were serialised by the runtime and only ever one working
+   * set (`slots`, `buckets`, signatures) was live. Yielding removes that
+   * accidental mutual exclusion: without this gate, K concurrent passes keep K
+   * working sets resident simultaneously — measured +17 % peak heap at K=4 and
+   * +67 % (+117 MB) at K=8 on a 2 500-job batch, and production batches are
+   * ~10x that.
+   *
+   * This service runs with `--max-old-space-size=2560` in a 4Gi container and
+   * has already aborted with `FATAL ERROR: Reached heap limit` (exit 139), so
+   * trading peak heap for concurrency is exactly the wrong trade here. The
+   * gate restores the old memory profile while keeping the win that motivated
+   * the yields: the pass that holds the gate still hands the event loop back
+   * every `DEFAULT_YIELD_BUDGET_MS`, so `GET /health` — and every other
+   * request — is served throughout.
+   *
+   * Queuing cost is negligible in practice: this endpoint serves a handful of
+   * searches an hour and the fan-out that produces the input already takes
+   * ~150 s, dwarfing any wait here.
+   */
   async dedup(jobs: ReadonlyArray<JobPostDto>): Promise<DedupResult> {
+    const prior = this.tail;
+    let release!: () => void;
+    this.tail = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    // `prior` can never reject (see `tail`), but stay defensive: a poisoned
+    // chain would turn a single bad batch into a permanent outage.
+    await prior.catch(() => undefined);
+    try {
+      return await this.dedupExclusive(jobs);
+    } finally {
+      release();
+    }
+  }
+
+  /** The pass itself. Only ever entered by one caller at a time — see {@link dedup}. */
+  private async dedupExclusive(jobs: ReadonlyArray<JobPostDto>): Promise<DedupResult> {
     const start = Date.now();
     const errors: DedupInputError[] = [];
     const prepared: PreparedJob[] = [];
     const inputCount = jobs.length;
+    const budget = new YieldBudget();
 
     // Pass 1 — validate + prepare. We keep `prepared` indices contiguous so
     // strategies can use a typed-array Union-Find later.
     for (let i = 0; i < inputCount; i++) {
+      // Yield checkpoint — `canonicalKey` + `canonicalJobId` normalise three
+      // fields twice and sha-256 the result: ~25 us per input, i.e. ~175 ms
+      // for a 6 900-job batch. Well under the probe timeout on its own, but
+      // free to slice and it keeps every pass under one bound.
+      if (budget.expired) {
+        await yieldToEventLoop();
+        budget.renew();
+      }
       const raw = jobs[i];
       if (!raw || !raw.title || !raw.companyName) {
         if (this.options.rejectInvalid) {
@@ -87,7 +159,14 @@ export class DedupHybridService implements IDedupEngine {
       indexToPos.set(prepared[pos].index, pos);
     }
     for (const strategy of this.strategies) {
-      const partition: ClusterPartition = strategy.cluster(prepared);
+      // Prefer the cooperative variant when a strategy offers one. `HashStrategy`
+      // does not (its pass is O(N) map inserts, ~1 ms for 7 K inputs);
+      // `MinHashStrategy` does, and it is the ~10 s pass this whole mechanism
+      // exists for.
+      const partition: ClusterPartition = strategy.clusterAsync
+        ? await strategy.clusterAsync(prepared)
+        : strategy.cluster(prepared);
+      budget.renew();
       for (const cluster of partition.clusters) {
         if (cluster.length < 2) continue;
         const headPos = indexToPos.get(cluster[0]);
@@ -106,6 +185,13 @@ export class DedupHybridService implements IDedupEngine {
     const assignments: (string | null)[] = new Array(inputCount).fill(null);
 
     for (const cluster of clusters) {
+      // Yield checkpoint — materialisation re-normalises title/company/location
+      // per cluster head (~10 us) and allocates a `CanonicalJob`; a
+      // mostly-unique 7 K batch emits ~7 K of them.
+      if (budget.expired) {
+        await yieldToEventLoop();
+        budget.renew();
+      }
       const observations: SourceObservation[] = [];
       const head = prepared[cluster[0]];
       const fields: Record<string, FieldWithProvenance<unknown>> = {};

--- a/packages/plugins/dedup-hybrid/src/index.ts
+++ b/packages/plugins/dedup-hybrid/src/index.ts
@@ -1,5 +1,6 @@
 export { DedupHybridModule } from './dedup-hybrid.module';
 export { DedupHybridService } from './dedup-hybrid.service';
+export { DEFAULT_YIELD_BUDGET_MS, YieldBudget, yieldToEventLoop } from './cooperative';
 export { HashStrategy } from './strategies/hash-strategy';
 export { MinHashStrategy, MinHashStrategyOptions } from './strategies/minhash-strategy';
 export {

--- a/packages/plugins/dedup-hybrid/src/strategies/minhash-strategy.ts
+++ b/packages/plugins/dedup-hybrid/src/strategies/minhash-strategy.ts
@@ -1,3 +1,4 @@
+import { YieldBudget, yieldToEventLoop } from '../cooperative';
 import { MinHasher, lshBandKeys, signatureSimilarity } from '../minhash';
 import { ClusterPartition, IDedupStrategy, PreparedJob } from '../types';
 import { UnionFind } from '../union-find';
@@ -98,6 +99,13 @@ interface SignatureSlot {
  * the same inputs and options: member order follows input order and component
  * order follows first-touch order (FR-7). Allocation-light: signatures are
  * typed arrays; bucket maps are cleared once the partition is materialised.
+ *
+ * Step 1 dominates: `MinHasher.signature()` runs `signatureSize x |shingles|`
+ * inner iterations, i.e. `128 x (tokens - 2)` per distinct text — ~160 M
+ * iterations for 1 000 postings of 800 tokens. That is why the pass has two
+ * entry points: {@link cluster} (synchronous, unchanged) and
+ * {@link clusterAsync} (same body, driven with `setImmediate` yields so the
+ * event loop — and therefore `GET /health` — stays alive).
  */
 export class MinHashStrategy implements IDedupStrategy {
   readonly name = 'minhash';
@@ -127,13 +135,71 @@ export class MinHashStrategy implements IDedupStrategy {
     });
   }
 
+  /**
+   * Synchronous entry point — unchanged semantics and unchanged timings.
+   * Drives {@link clusterSteps} with no budget, so the generator never
+   * suspends and the whole pass runs in one turn (exactly what it did before
+   * the split).
+   */
   cluster(input: ReadonlyArray<PreparedJob>): ClusterPartition {
+    const steps = this.clusterSteps(input, null);
+    let step = steps.next();
+    while (!step.done) step = steps.next();
+    return step.value;
+  }
+
+  /**
+   * Cooperative entry point — byte-identical output to {@link cluster},
+   * because it drives the *same* generator body; the only difference is that
+   * it parks on `setImmediate` at each checkpoint whose budget has expired.
+   *
+   * Safe to interleave with other requests: every structure the body touches
+   * (`slotByText`, `slots`, `buckets`, `uf`, `seenPairs`, `clusters`) is a
+   * local of this call, and the only instance state it reads
+   * (`minTextLength`, `hasher`, `bands`, `maxBucketSize`,
+   * `similarityThreshold`) is `readonly` and assigned once in the constructor.
+   * Two concurrent calls therefore share nothing mutable.
+   */
+  async clusterAsync(input: ReadonlyArray<PreparedJob>): Promise<ClusterPartition> {
+    const budget = new YieldBudget();
+    const steps = this.clusterSteps(input, budget);
+    let step = steps.next();
+    while (!step.done) {
+      await yieldToEventLoop();
+      budget.renew();
+      step = steps.next();
+    }
+    return step.value;
+  }
+
+  /**
+   * The clustering pass itself, expressed once as a generator so both entry
+   * points share a single implementation.
+   *
+   * `yield` marks a point where the pass is safe to suspend — all state is
+   * local and internally consistent at every checkpoint. With `budget === null`
+   * no checkpoint ever fires and the generator returns on the first `next()`.
+   *
+   * A generator rather than a plain `async` body on purpose: measured on Node
+   * 24, putting an `await` inside the candidate-pair loop costs ~45 %
+   * throughput (V8's async-function resumable transform), while the same loop
+   * inside a generator costs ~1-4 %.
+   */
+  private *clusterSteps(
+    input: ReadonlyArray<PreparedJob>,
+    budget: YieldBudget | null,
+  ): Generator<void, ClusterPartition, void> {
     if (input.length < 2) return { clusters: [] };
 
     // Group identical texts into slots — one signature per distinct text.
     const slotByText = new Map<string, number>();
     const slots: SignatureSlot[] = [];
     for (let i = 0; i < input.length; i++) {
+      // Checkpoint — THE dominant loop. One `signature()` call is 0.16 ms
+      // (200-token text) to 0.61 ms (800 tokens) of straight-line CPU, so the
+      // budget is checked once per input: ~0.10 us of clock read against
+      // ~0.3 ms of work, and 10 ms of budget lands every ~16-60 inputs.
+      if (budget !== null && budget.expired) yield;
       const job = input[i];
       const text = pickText(job);
       if (text.length < this.minTextLength) continue;
@@ -152,6 +218,10 @@ export class MinHashStrategy implements IDedupStrategy {
     // LSH bucketing — slot indices stored per band-key.
     const buckets = new Map<string, number[]>();
     for (let i = 0; i < slots.length; i++) {
+      // Checkpoint — `lshBandKeys` renders `signatureSize` hex rows into
+      // `bands` strings per slot (~25 us at the 128/16 default), so ~400 slots
+      // per 10 ms slice.
+      if (budget !== null && budget.expired) yield;
       const keys = lshBandKeys(slots[i].signature, this.bands);
       for (const key of keys) {
         const bucket = buckets.get(key);
@@ -167,8 +237,17 @@ export class MinHashStrategy implements IDedupStrategy {
     const uf = new UnionFind(slots.length);
     const seenPairs = new Set<number>();
 
-    buckets.forEach((bucket) => {
-      if (bucket.length < 2) return;
+    // `Map` iteration order is insertion order, identical to what `forEach`
+    // visited before — the partition is unchanged. Iterating (rather than
+    // `forEach`) is what makes the checkpoint below expressible.
+    for (const bucket of buckets.values()) {
+      if (bucket.length < 2) continue;
+      // Checkpoint — per bucket, not per pair. One bucket is capped at
+      // `maxBucketSize` members, so it evaluates at most
+      // 200*199/2 = 19 900 pairs at ~0.2 us each ≈ 4 ms: a per-bucket check
+      // already bounds the block at budget + ~4 ms, and costs one clock read
+      // instead of one per pair.
+      if (budget !== null && budget.expired) yield;
       const cap = Math.min(bucket.length, this.maxBucketSize);
       for (let i = 0; i < cap; i++) {
         for (let j = i + 1; j < cap; j++) {
@@ -189,13 +268,16 @@ export class MinHashStrategy implements IDedupStrategy {
           }
         }
       }
-    });
+    }
 
     // Emit each connected component — expanded from slots back to job
     // indices — as one cluster. Single-slot components still emit when the
     // slot holds ≥ 2 identical-text members (FR-5).
     const clusters: number[][] = [];
     for (const component of uf.toClusters()) {
+      // Checkpoint — cheap per component, but a duplicate-heavy batch can emit
+      // thousands and each sorts its member list.
+      if (budget !== null && budget.expired) yield;
       let size = 0;
       for (const slot of component) size += slots[slot].members.length;
       if (size < 2) continue;

--- a/packages/plugins/dedup-hybrid/src/types.ts
+++ b/packages/plugins/dedup-hybrid/src/types.ts
@@ -32,6 +32,22 @@ export interface ClusterPartition {
 export interface IDedupStrategy {
   readonly name: string;
   cluster(input: ReadonlyArray<PreparedJob>): ClusterPartition;
+  /**
+   * Optional cooperative variant of {@link cluster}: **identical output**, but
+   * it hands the event loop back (`setImmediate`) roughly every
+   * `DEFAULT_YIELD_BUDGET_MS` of CPU so the process keeps answering
+   * `GET /health` while a large batch clusters.
+   *
+   * `DedupHybridService` calls this when a strategy provides it and falls back
+   * to the synchronous {@link cluster} otherwise, so implementing it is
+   * strictly opt-in — a strategy whose pass is already short (e.g.
+   * `HashStrategy`, O(N) map inserts) has no reason to.
+   *
+   * Implementations MUST return the same partition as `cluster` for the same
+   * input; the intended shape is one generator body driven by both entry
+   * points, so there is no second copy of the algorithm to drift.
+   */
+  clusterAsync?(input: ReadonlyArray<PreparedJob>): Promise<ClusterPartition>;
 }
 
 /**


### PR DESCRIPTION
Completes the `develop → stage → main` cascade of #38 / #39.

- `fix(dedup)`: cooperative yields so a ~10.6 s clustering pass stops starving `GET /health`, plus a serialisation gate so the yields do not raise peak heap.
- `ci(build)`: `:latest` published from `main` only. **This is the branch where that takes effect** — from here on `:latest` means production.

Merging rebuilds `:prod` (the diff touches `packages/**`); ArgoCD Image Updater resolves the digest and `ever-jobs-prod` rolls with `maxUnavailable: 0`.

Context: prod aborted twice today with `FATAL ERROR: Reached heap limit` (exit 139). The heap fix shipped separately in [k8s-gitops#46](https://github.com/ever-co/k8s-gitops/pull/46) (`CACHE_MAX_ITEMS=1`) and prod has been stable since — idle RSS 246-524 MiB, 0 restarts.