### PR TITLE
Promote stage → main: node-gyp offline headers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,27 @@ WORKDIR /app
 # node_modules and stays slim.
 RUN apk add --no-cache python3 make g++ libc-dev
 
+# Build native modules against the headers ALREADY IN THIS IMAGE instead of
+# downloading them.
+#
+# `better-sqlite3` publishes no prebuilt binary for musl, so `prebuild-install`
+# always misses and falls back to `node-gyp rebuild`. node-gyp then fetches
+# https://unofficial-builds.nodejs.org/download/release/v20.20.2/node-v20.20.2-headers.tar.gz,
+# and that host is reached from an ARC runner pod with unreliable egress — it
+# ETIMEDOUTs intermittently and fails the whole image build. It cost two
+# re-runs on 2026-08-01 alone (03:26 and 17:17); a plain re-run "fixed" it both
+# times, which is exactly what makes it easy to keep dismissing as noise.
+#
+# node:20-alpine already ships the complete header set at
+# /usr/local/include/node (node.h, common.gypi, config.gypi), so pointing
+# node-gyp at it removes the download entirely — the build no longer depends on
+# reaching an external host at all.
+#
+# Verified in a node:20-alpine pod: with this set, `npm install better-sqlite3
+# --build-from-source` emits `gyp info ok` with NO `gyp http GET` and no
+# headers.tar.gz fetch, and the compiled module loads.
+ENV npm_config_nodedir=/usr/local
+
 # Copy dependency manifests
 COPY package*.json ./
 


### PR DESCRIPTION
Completes the `develop → stage → main` cascade of #41 / #42.

`ENV npm_config_nodedir=/usr/local` — node-gyp builds `better-sqlite3` against the headers already in `node:20-alpine` instead of fetching them over the network. Removes a network dependency from every image build rather than retrying it.

Confirmed in real CI: Docker Build success, 0 cached layers, `npm ci` ran fresh, no `gyp http GET` / `headers.tar.gz` / ETIMEDOUT.