### PR TITLE
fix(security,memory): allowlist the submit4jobs API host + bound the PDF fetches

### DIFF
--- a/packages/plugins/source-ats-submit4jobs/__tests__/submit4jobs-ssrf-guard.spec.ts
+++ b/packages/plugins/source-ats-submit4jobs/__tests__/submit4jobs-ssrf-guard.spec.ts
@@ -1,0 +1,60 @@
+import {
+  isAllowedSubmit4jobsApiHost,
+  SUBMIT4JOBS_EMBED_REGEX,
+} from '../src/submit4jobs.constants';
+
+/**
+ * SSRF gate for the discovered embed API host.
+ *
+ * `apiHost` is capture group 1 of SUBMIT4JOBS_EMBED_REGEX — it comes from the
+ * scraped tenant board's own HTML — and is then interpolated into the URLs we
+ * request *with the ColdFusion session cookies attached*. The regex constrains
+ * only the SHAPE of a host, so a tenant able to edit their board page could
+ * otherwise redirect our scraper anywhere.
+ */
+describe('submit4jobs — apiHost allowlist', () => {
+  it('accepts both real Pereless host families', () => {
+    // Allowlisting only submit4jobs.com would silently break every tenant
+    // served from the pereless.com host.
+    expect(isAllowedSubmit4jobsApiHost('apps.submit4jobs.com')).toBe(true);
+    expect(isAllowedSubmit4jobsApiHost('devapps.pereless.com')).toBe(true);
+    expect(isAllowedSubmit4jobsApiHost('APPS.SUBMIT4JOBS.COM')).toBe(true);
+  });
+
+  it('rejects the hosts an attacker would actually aim at', () => {
+    for (const host of [
+      '169.254.169.254', // cloud metadata
+      '10.0.0.5', // internal RFC1918
+      '127.0.0.1',
+      'localhost',
+      'evil.example',
+      'attacker.com',
+    ]) {
+      expect(isAllowedSubmit4jobsApiHost(host)).toBe(false);
+    }
+  });
+
+  it('is not fooled by suffix-lookalikes or embedded credentials', () => {
+    for (const host of [
+      'evil.com/x.submit4jobs.com', // path smuggling
+      'user@evil.com', // credential smuggling
+      'evil.com#.submit4jobs.com', // fragment smuggling
+      'evil.com:8080', // port
+      'notsubmit4jobs.com', // missing dot boundary
+      'submit4jobs.com.evil.com', // suffix in the middle
+      '',
+    ]) {
+      expect(isAllowedSubmit4jobsApiHost(host)).toBe(false);
+    }
+  });
+
+  it('the embed regex alone does NOT constrain the host — hence this guard', () => {
+    // Proves the guard is load-bearing rather than redundant.
+    const hostile =
+      '<script src="//169.254.169.254/templates/magneto/embed/iframe.cfm?cid=1"></script>';
+    const match = SUBMIT4JOBS_EMBED_REGEX.exec(hostile);
+    expect(match).not.toBeNull();
+    expect(match?.[1]).toBe('169.254.169.254');
+    expect(isAllowedSubmit4jobsApiHost(match![1])).toBe(false);
+  });
+});

--- a/packages/plugins/source-ats-submit4jobs/src/submit4jobs.constants.ts
+++ b/packages/plugins/source-ats-submit4jobs/src/submit4jobs.constants.ts
@@ -27,6 +27,48 @@
 /** Host suffix — every tenant board lives at `{slug}.submit4jobs.com`. */
 export const SUBMIT4JOBS_HOST_SUFFIX = '.submit4jobs.com';
 
+/**
+ * Domains the discovered `apiHost` is allowed to live on.
+ *
+ * 🛑 SECURITY — this is an SSRF gate, not tidiness. `apiHost` is capture group 1
+ * of {@link SUBMIT4JOBS_EMBED_REGEX}, i.e. it comes from the *scraped tenant
+ * board's own HTML*, and it is then interpolated into the URLs that
+ * `primeSession` and `getJobs` request — carrying the ColdFusion session
+ * cookies. The regex only constrains the SHAPE of the host (`[a-z0-9.-]+`), so
+ * without this check anyone able to edit a `*.submit4jobs.com` board page could
+ * point our scraper at an arbitrary host: an internal cluster address, a
+ * link-local metadata endpoint, or their own collector.
+ *
+ * Both entries are required. Observed pairs are `apps.submit4jobs.com`/`magneto`
+ * AND `devapps.pereless.com`/`magnetolive` — Pereless Systems is the upstream
+ * vendor that white-labels these boards, so allowlisting only `submit4jobs.com`
+ * would silently break every tenant served from the `pereless.com` host.
+ */
+export const SUBMIT4JOBS_ALLOWED_API_HOST_SUFFIXES: readonly string[] = [
+  '.submit4jobs.com',
+  '.pereless.com',
+];
+
+/**
+ * `true` when `host` is a bare hostname on one of
+ * {@link SUBMIT4JOBS_ALLOWED_API_HOST_SUFFIXES}.
+ *
+ * Rejects anything carrying credentials, a port, a path, or an IP literal — an
+ * embed URL never needs them, and each is a way to slip past a naive
+ * `endsWith` (`evil.com/x.submit4jobs.com`, `10.0.0.1:80`,
+ * `user@evil.com#.submit4jobs.com`).
+ */
+export function isAllowedSubmit4jobsApiHost(host: string): boolean {
+  if (!host) return false;
+  const h = host.trim().toLowerCase();
+  // Bare hostname only: letters/digits/dot/hyphen, no `@`, `:`, `/`, `#`, `?`.
+  if (!/^[a-z0-9.-]+$/.test(h)) return false;
+  if (h.includes('..') || h.startsWith('.') || h.startsWith('-')) return false;
+  return SUBMIT4JOBS_ALLOWED_API_HOST_SUFFIXES.some((suffix) =>
+    h.endsWith(suffix),
+  );
+}
+
 /** Default results cap when the caller omits `resultsWanted`. */
 export const SUBMIT4JOBS_DEFAULT_RESULTS = 100;
 

--- a/packages/plugins/source-ats-submit4jobs/src/submit4jobs.service.ts
+++ b/packages/plugins/source-ats-submit4jobs/src/submit4jobs.service.ts
@@ -28,6 +28,7 @@ import {
   SUBMIT4JOBS_SESSION_COOKIES,
   SUBMIT4JOBS_HEADERS,
   SUBMIT4JOBS_EMBED_REGEX,
+  isAllowedSubmit4jobsApiHost,
   SUBMIT4JOBS_SALARY_TYPE_MAP,
   submit4jobsBoardUrl,
   submit4jobsJobUrl,
@@ -150,7 +151,23 @@ export class Submit4jobsService implements IScraper {
     if (!html) return null;
     const match = SUBMIT4JOBS_EMBED_REGEX.exec(html);
     if (!match) return null;
-    return { apiHost: match[1], template: match[2], cid: match[3] };
+    const [, apiHost, template, cid] = match;
+
+    // 🛑 SSRF gate. `apiHost` is read out of the tenant board's own HTML and is
+    // about to be interpolated into the URLs we request WITH the ColdFusion
+    // session cookies attached. The embed regex only constrains the host's
+    // shape, so without this check a tenant who can edit their board page could
+    // redirect our scraper at an internal address or their own collector.
+    // Fail closed: an unrecognised host yields no coordinates, so the scrape
+    // returns [] exactly as it does for a board with no embed at all.
+    if (!isAllowedSubmit4jobsApiHost(apiHost)) {
+      this.logger.warn(
+        `Submit4Jobs: refusing embed API host \`${apiHost}\` for ${slug} — not on an allowed domain`,
+      );
+      return null;
+    }
+
+    return { apiHost, template, cid };
   }
 
   /**

--- a/packages/plugins/source-company-canekast/src/canekast.constants.ts
+++ b/packages/plugins/source-company-canekast/src/canekast.constants.ts
@@ -42,3 +42,29 @@ export const CANEKAST_PDF_HREF_RE = /\/wp-content\/uploads\/[^"'\s]+\.pdf(?:[?#]
  */
 export const canekastLetterheadRe = (): RegExp =>
   /\d{1,6}\s+[A-Za-z0-9 .'-]+?\s+([A-Za-z.'-]+),\s*([A-Z]{2})\s+\d{5}(?:\s*Phone\s*[\d().+\-\s]{7,16})?/g;
+
+/**
+ * Hard ceiling on a single job-description PDF, in bytes.
+ *
+ * 🛑 MEMORY — the fetch buffers the whole response as an ArrayBuffer, then
+ * `toPlainUint8Array` copies it again, then unpdf (pdf.js) allocates more
+ * while parsing. So the peak cost of one PDF is a multiple of its wire size.
+ * This API runs with `--max-old-space-size=2560` inside a 4Gi container and
+ * has aborted twice with `FATAL ERROR: Reached heap limit`, where RSS — not
+ * heap — was the binding constraint. An unbounded read of a remote file we do
+ * not control is exactly the shape that reproduces that.
+ *
+ * 8 MiB is ~10x the largest observed posting PDF; anything above it is not a
+ * job description.
+ */
+export const CANEKAST_PDF_MAX_BYTES = 8 * 1024 * 1024;
+
+/**
+ * Max PDFs fetched+parsed at once.
+ *
+ * 🛑 Bounds PEAK residency, which the per-file cap alone does not: an
+ * unbounded `Promise.allSettled` over the listing holds EVERY decoded PDF in
+ * memory simultaneously, so a page with 40 openings peaks at 40x. With this
+ * cap the worst case is CANEKAST_PDF_MAX_BYTES x this number.
+ */
+export const CANEKAST_PDF_CONCURRENCY = 4;

--- a/packages/plugins/source-company-canekast/src/canekast.service.ts
+++ b/packages/plugins/source-company-canekast/src/canekast.service.ts
@@ -16,6 +16,8 @@ import {
   CANEKAST_COMPANY_NAME,
   CANEKAST_DEFAULT_RESULTS,
   CANEKAST_DEFAULT_TIMEOUT_SECONDS,
+  CANEKAST_PDF_MAX_BYTES,
+  CANEKAST_PDF_CONCURRENCY,
   CANEKAST_ORIGIN,
   CANEKAST_PDF_HREF_RE,
   canekastLetterheadRe,
@@ -47,26 +49,46 @@ export class CanekastService implements IScraper {
         return new JobResponseDto([]);
       }
 
-      const settled = await Promise.allSettled(
-        openings.map(async (opening) => {
+      // Bounded worker pool. The previous `Promise.allSettled(openings.map(...))`
+      // fetched and decoded EVERY PDF simultaneously, so peak memory scaled with
+      // the size of the listing rather than with anything we control. Workers
+      // pull from a shared cursor, so at most CANEKAST_PDF_CONCURRENCY PDFs are
+      // resident at once. Results are written by index, so ordering is
+      // identical to the previous implementation.
+      const collected: (JobPostDto | undefined)[] = new Array(openings.length);
+      let cursor = 0;
+      const worker = async (): Promise<void> => {
+        for (let i = cursor++; i < openings.length; i = cursor++) {
+          const opening = openings[i];
           let text = '';
           try {
             text = await this.fetchPdfText(client, opening.pdfUrl);
           } catch (error: unknown) {
+            // Unchanged semantics: a failed fetch still yields a post, just
+            // without the description body.
             this.logger.warn(
               `CaneKast: PDF fetch/parse failed for ${opening.pdfUrl} (${this.errorLabel(error)})`,
             );
           }
-          return this.toJobPost(opening, text);
-        }),
+          try {
+            collected[i] = this.toJobPost(opening, text);
+          } catch (error: unknown) {
+            // Matches the old `.filter(status === 'fulfilled')`: a posting that
+            // cannot be mapped is dropped rather than failing the whole scrape.
+            this.logger.warn(
+              `CaneKast: could not map ${opening.pdfUrl} (${this.errorLabel(error)})`,
+            );
+          }
+        }
+      };
+      await Promise.all(
+        Array.from(
+          { length: Math.min(CANEKAST_PDF_CONCURRENCY, openings.length) },
+          () => worker(),
+        ),
       );
 
-      const jobs = settled
-        .filter(
-          (s): s is PromiseFulfilledResult<JobPostDto> =>
-            s.status === 'fulfilled',
-        )
-        .map((s) => s.value);
+      const jobs = collected.filter((j): j is JobPostDto => j !== undefined);
 
       const out = this.applyInput(jobs, input);
       this.logger.log(`CaneKast: scraped ${out.length} jobs`);
@@ -101,6 +123,10 @@ export class CanekastService implements IScraper {
   ): Promise<string> {
     const res = await client.get<ArrayBuffer | Uint8Array>(url, {
       responseType: 'arraybuffer',
+      // Refuse an oversized PDF at the transport layer, not after the whole
+      // body is already resident. See CANEKAST_PDF_MAX_BYTES.
+      maxContentLength: CANEKAST_PDF_MAX_BYTES,
+      maxBodyLength: CANEKAST_PDF_MAX_BYTES,
     });
     return extractPdfText(res.data);
   }

--- a/packages/plugins/source-company-desktopmetal/src/desktopmetal.constants.ts
+++ b/packages/plugins/source-company-desktopmetal/src/desktopmetal.constants.ts
@@ -30,7 +30,13 @@ export const DESKTOPMETAL_DEFAULT_RESULTS = 50;
 /** Default per-request timeout (seconds). */
 export const DESKTOPMETAL_DEFAULT_TIMEOUT_SECONDS = 30;
 
-/** Bounded concurrency for the per-role PDF fetches. */
+/**
+ * Bounded concurrency for the per-role PDF fetches.
+ *
+ * Declared by the plugin author but left unwired — the fan-out was an
+ * unbounded `Promise.allSettled` over every opening. Now actually enforced by
+ * the worker pool in `desktopmetal.service.ts`, at the value they chose.
+ */
 export const DESKTOPMETAL_PDF_CONCURRENCY = 4;
 
 /**
@@ -50,3 +56,20 @@ export const DESKTOPMETAL_PAY_INTERVALS: ReadonlyArray<
     CompensationInterval.YEARLY,
   ],
 ];
+
+/**
+ * Hard ceiling on a single job-description PDF, in bytes.
+ *
+ * 🛑 MEMORY — the fetch buffers the whole response as an ArrayBuffer, then
+ * `toPlainUint8Array` copies it again, then unpdf (pdf.js) allocates more
+ * while parsing. So the peak cost of one PDF is a multiple of its wire size.
+ * This API runs with `--max-old-space-size=2560` inside a 4Gi container and
+ * has aborted twice with `FATAL ERROR: Reached heap limit`, where RSS — not
+ * heap — was the binding constraint. An unbounded read of a remote file we do
+ * not control is exactly the shape that reproduces that.
+ *
+ * 8 MiB is ~10x the largest observed posting PDF; anything above it is not a
+ * job description.
+ */
+export const DESKTOPMETAL_PDF_MAX_BYTES = 8 * 1024 * 1024;
+

--- a/packages/plugins/source-company-desktopmetal/src/desktopmetal.service.ts
+++ b/packages/plugins/source-company-desktopmetal/src/desktopmetal.service.ts
@@ -25,6 +25,8 @@ import {
   DESKTOPMETAL_COMPANY_NAME,
   DESKTOPMETAL_DEFAULT_RESULTS,
   DESKTOPMETAL_DEFAULT_TIMEOUT_SECONDS,
+  DESKTOPMETAL_PDF_MAX_BYTES,
+  DESKTOPMETAL_PDF_CONCURRENCY,
   DESKTOPMETAL_ORIGIN,
   DESKTOPMETAL_PAY_INTERVALS,
 } from './desktopmetal.constants';
@@ -56,26 +58,46 @@ export class DesktopmetalService implements IScraper, OnModuleDestroy {
           input.requestTimeout ?? DESKTOPMETAL_DEFAULT_TIMEOUT_SECONDS,
       });
 
-      const settled = await Promise.allSettled(
-        openings.map(async (opening) => {
+      // Bounded worker pool. The previous `Promise.allSettled(openings.map(...))`
+      // fetched and decoded EVERY PDF simultaneously, so peak memory scaled with
+      // the size of the listing rather than with anything we control. Workers
+      // pull from a shared cursor, so at most DESKTOPMETAL_PDF_CONCURRENCY PDFs are
+      // resident at once. Results are written by index, so ordering is
+      // identical to the previous implementation.
+      const collected: (JobPostDto | undefined)[] = new Array(openings.length);
+      let cursor = 0;
+      const worker = async (): Promise<void> => {
+        for (let i = cursor++; i < openings.length; i = cursor++) {
+          const opening = openings[i];
           let text = '';
           try {
             text = await this.fetchPdfText(client, opening.pdfUrl);
           } catch (error: unknown) {
+            // Unchanged semantics: a failed fetch still yields a post, just
+            // without the description body.
             this.logger.warn(
               `Desktop Metal: PDF fetch/parse failed for ${opening.pdfUrl} (${this.errorLabel(error)})`,
             );
           }
-          return this.toJobPost(opening, text, applyEmail);
-        }),
+          try {
+            collected[i] = this.toJobPost(opening, text, applyEmail);
+          } catch (error: unknown) {
+            // Matches the old `.filter(status === 'fulfilled')`: a posting that
+            // cannot be mapped is dropped rather than failing the whole scrape.
+            this.logger.warn(
+              `Desktop Metal: could not map ${opening.pdfUrl} (${this.errorLabel(error)})`,
+            );
+          }
+        }
+      };
+      await Promise.all(
+        Array.from(
+          { length: Math.min(DESKTOPMETAL_PDF_CONCURRENCY, openings.length) },
+          () => worker(),
+        ),
       );
 
-      const jobs = settled
-        .filter(
-          (s): s is PromiseFulfilledResult<JobPostDto> =>
-            s.status === 'fulfilled',
-        )
-        .map((s) => s.value);
+      const jobs = collected.filter((j): j is JobPostDto => j !== undefined);
 
       const out = this.applyInput(jobs, input);
       this.logger.log(`Desktop Metal: scraped ${out.length} jobs`);
@@ -129,6 +151,10 @@ export class DesktopmetalService implements IScraper, OnModuleDestroy {
   ): Promise<string> {
     const res = await client.get<ArrayBuffer | Uint8Array>(url, {
       responseType: 'arraybuffer',
+      // Refuse an oversized PDF at the transport layer, not after the whole
+      // body is already resident. See DESKTOPMETAL_PDF_MAX_BYTES.
+      maxContentLength: DESKTOPMETAL_PDF_MAX_BYTES,
+      maxBodyLength: DESKTOPMETAL_PDF_MAX_BYTES,
     });
     return extractPdfText(res.data);
   }


### PR DESCRIPTION
The two hardening items flagged during the [#44](https://github.com/ever-jobs/ever-jobs/pull/44) fork review.

## 1. SSRF — `submit4jobs` took its API host verbatim from scraped HTML

`apiHost` is capture group 1 of `SUBMIT4JOBS_EMBED_REGEX` — read out of the **tenant board's own page** — and was interpolated straight into the URLs `primeSession()` and `getJobs()` request, **with the ColdFusion session cookies attached**. The regex constrains only the *shape* of a host (`[a-z0-9.-]+`), so `169.254.169.254`, `10.0.0.5` and `evil.example` all matched.

`isAllowedSubmit4jobsApiHost()` now gates it and `discover()` **fails closed** — an unrecognised host yields no coordinates, so the scrape returns `[]` exactly as it does for a board with no embed.

**The allowlist deliberately carries two domains.** The constants file documents observed pairs `apps.submit4jobs.com`/`magneto` **and** `devapps.pereless.com`/`magnetolive` — Pereless is the upstream vendor white-labelling these boards, so allowlisting only `submit4jobs.com` would have **silently broken every tenant on the pereless.com host**. The check also rejects credential/port/path/fragment smuggling rather than a naive `endsWith`.

## 2. Memory — the new `unpdf` path was unbounded in two dimensions

`fetchPdfText` buffered the whole response with no `maxContentLength`, `toPlainUint8Array` copied it again, and unpdf (pdf.js) allocated more on parse. Separately, `Promise.allSettled(openings.map(...))` fetched and decoded **every** PDF at once, so peak residency scaled with the listing.

This API runs `--max-old-space-size=2560` in a 4Gi container and aborted twice on 2026-08-01 with `FATAL ERROR: Reached heap limit`, where **RSS — not heap — was the binding constraint**. An unbounded read of a remote file we don't control is exactly that shape.

- `*_PDF_MAX_BYTES` (8 MiB) as `maxContentLength`/`maxBodyLength` — refused at the transport layer, not after it's resident
- A bounded worker pool replaces the fan-out; results written **by index**, so ordering is unchanged
- `desktopmetal` already **declared** `DESKTOPMETAL_PDF_CONCURRENCY = 4` but never wired it up — this implements what the author intended, at their value

Semantics preserved exactly: a failed fetch still yields a post without a description body, and an unmappable posting is dropped rather than failing the scrape — matching the old `.filter(status === 'fulfilled')`.

## What I deliberately did *not* do

I'd originally suggested **slicing the openings before fetching**. That's unsafe here: `applyFilters` filters on `job.description`, `job.location`, `job.isRemote` and `job.jobType` — **all derived from the PDF text** — so slicing early would silently change results whenever a filter is supplied. Bounding size and concurrency is what actually fixes the memory risk.

## Verified

- `tsc --noEmit -p tsconfig.base.json` clean
- **38/38** tests across the three affected plugins
- The SSRF test is **mutation-checked**: stubbing the gate to `return true` fails 3 of its 4 cases, so it's provably load-bearing