### PR TITLE
Promote stage → main: direct Upwork OAuth2+GraphQL client

### DIFF
--- a/packages/plugins/source-upwork/__tests__/upwork.client.spec.ts
+++ b/packages/plugins/source-upwork/__tests__/upwork.client.spec.ts
@@ -1,0 +1,246 @@
+import { UpworkAuthDto, UpworkGrantType } from '@ever-jobs/models';
+
+import {
+  UpworkTokenProvider,
+  executeUpworkGraphql,
+  UpworkApiError,
+} from '../src/upwork.client';
+import {
+  UPWORK_TOKEN_URL,
+  UPWORK_GRAPHQL_URL,
+} from '../src/upwork.constants';
+
+/**
+ * Wire contract for the direct Upwork client that replaced
+ * `@upwork/node-upwork-oauth2`.
+ *
+ * These assertions are transcribed from the SDK's own source (2.3.0) rather
+ * than from documentation, because an SDK replacement fails in exactly one
+ * way: it *looks* right and returns 401 in production. The load-bearing facts:
+ *
+ *   - credentials go in the request BODY (`authorizationMethod: 'body'`),
+ *     NOT an `Authorization: Basic` header;
+ *   - the token endpoint is www.upwork.com, the GraphQL endpoint is
+ *     api.upwork.com — two different hosts;
+ *   - GraphQL `variables` is sent as a JSON STRING;
+ *   - GraphQL reports failures in-band with HTTP 200.
+ */
+
+// Capture every outbound call without performing one.
+const posts: { url: string; body: any; config: any }[] = [];
+let nextResponse: (url: string) => any;
+
+jest.mock('@ever-jobs/common', () => {
+  const actual = jest.requireActual('@ever-jobs/common');
+  return {
+    ...actual,
+    createHttpClient: () => ({
+      post: jest.fn(async (url: string, body: any, config: any) => {
+        posts.push({ url, body, config });
+        return nextResponse(url);
+      }),
+    }),
+  };
+});
+
+const clientCreds = () =>
+  new UpworkAuthDto({ clientId: 'cid-123', clientSecret: 'secret-xyz' });
+
+beforeEach(() => {
+  posts.length = 0;
+  nextResponse = (url) =>
+    url === UPWORK_TOKEN_URL
+      ? { data: { access_token: 'tok-1', expires_in: 3600 } }
+      : { data: { data: { marketplaceJobPostings: { edges: [] } } } };
+});
+
+describe('UpworkTokenProvider — client_credentials', () => {
+  it('posts to the token endpoint with credentials in the BODY, not a Basic header', async () => {
+    const tokens = new UpworkTokenProvider(
+      clientCreds(),
+      UpworkGrantType.CLIENT_CREDENTIALS,
+    );
+    await tokens.getAccessToken();
+
+    expect(posts).toHaveLength(1);
+    expect(posts[0].url).toBe(UPWORK_TOKEN_URL);
+
+    const body = new URLSearchParams(posts[0].body as string);
+    expect(body.get('grant_type')).toBe('client_credentials');
+    expect(body.get('client_id')).toBe('cid-123');
+    expect(body.get('client_secret')).toBe('secret-xyz');
+    expect(posts[0].config.headers['Content-Type']).toBe(
+      'application/x-www-form-urlencoded',
+    );
+
+    // 🛑 The regression this guards: Basic auth here returns 401 from Upwork.
+    expect(posts[0].config.headers.Authorization).toBeUndefined();
+  });
+
+  it('caches the token so a fan-out costs one token request', async () => {
+    const tokens = new UpworkTokenProvider(
+      clientCreds(),
+      UpworkGrantType.CLIENT_CREDENTIALS,
+    );
+    await tokens.getAccessToken();
+    await tokens.getAccessToken();
+    await tokens.getAccessToken();
+
+    expect(posts.filter((p) => p.url === UPWORK_TOKEN_URL)).toHaveLength(1);
+  });
+
+  it('never leaks the client secret into the error message', async () => {
+    nextResponse = () => {
+      throw Object.assign(new Error('boom'), {
+        response: { status: 400, data: { client_secret: 'secret-xyz' } },
+      });
+    };
+    const tokens = new UpworkTokenProvider(
+      clientCreds(),
+      UpworkGrantType.CLIENT_CREDENTIALS,
+    );
+
+    await expect(tokens.getAccessToken()).rejects.toThrow(UpworkApiError);
+    await expect(tokens.getAccessToken()).rejects.not.toThrow(
+      /secret-xyz/,
+    );
+  });
+});
+
+describe('UpworkTokenProvider — authorization_code', () => {
+  it('uses a caller-supplied access token without contacting the token endpoint', async () => {
+    const tokens = new UpworkTokenProvider(
+      new UpworkAuthDto({
+        clientId: 'cid',
+        clientSecret: 'sec',
+        accessToken: 'caller-token',
+        refreshToken: 'refresh-token',
+      }),
+      UpworkGrantType.AUTHORIZATION_CODE,
+    );
+
+    expect(await tokens.getAccessToken()).toBe('caller-token');
+    expect(posts).toHaveLength(0);
+  });
+
+  it('refreshes with grant_type=refresh_token when forced', async () => {
+    nextResponse = () => ({
+      data: { access_token: 'tok-2', refresh_token: 'refresh-2', expires_in: 60 },
+    });
+    const tokens = new UpworkTokenProvider(
+      new UpworkAuthDto({
+        clientId: 'cid',
+        clientSecret: 'sec',
+        accessToken: 'stale',
+        refreshToken: 'refresh-1',
+      }),
+      UpworkGrantType.AUTHORIZATION_CODE,
+    );
+
+    expect(await tokens.getAccessToken(true)).toBe('tok-2');
+    const body = new URLSearchParams(posts[0].body as string);
+    expect(body.get('grant_type')).toBe('refresh_token');
+    expect(body.get('refresh_token')).toBe('refresh-1');
+  });
+
+  it('fails clearly when a refresh is needed but no refresh token exists', async () => {
+    const tokens = new UpworkTokenProvider(
+      new UpworkAuthDto({ clientId: 'cid', clientSecret: 'sec' }),
+      UpworkGrantType.AUTHORIZATION_CODE,
+    );
+    await expect(tokens.getAccessToken()).rejects.toThrow(/refreshToken/);
+  });
+});
+
+describe('executeUpworkGraphql', () => {
+  const tokens = () =>
+    new UpworkTokenProvider(clientCreds(), UpworkGrantType.CLIENT_CREDENTIALS);
+
+  it('posts to the GraphQL host with a Bearer token and JSON-string variables', async () => {
+    await executeUpworkGraphql(tokens(), {
+      query: 'query {}',
+      variables: { first: 5 },
+    });
+
+    const gql = posts.find((p) => p.url === UPWORK_GRAPHQL_URL);
+    expect(gql).toBeDefined();
+    // Two DIFFERENT hosts — token on www, GraphQL on api.
+    expect(UPWORK_GRAPHQL_URL).not.toContain('www.upwork.com');
+    expect(gql!.config.headers.Authorization).toBe('Bearer tok-1');
+    expect(gql!.config.headers['Content-Type']).toBe('application/json');
+    // Upwork requires `variables` as a STRING, not a nested object.
+    expect(typeof gql!.body.variables).toBe('string');
+    expect(JSON.parse(gql!.body.variables)).toEqual({ first: 5 });
+  });
+
+  it('passes an already-stringified variables payload through untouched', async () => {
+    await executeUpworkGraphql(tokens(), {
+      query: 'query {}',
+      variables: '{"first":7}',
+    });
+    const gql = posts.find((p) => p.url === UPWORK_GRAPHQL_URL);
+    expect(gql!.body.variables).toBe('{"first":7}');
+  });
+
+  it('unwraps the GraphQL data envelope', async () => {
+    nextResponse = (url) =>
+      url === UPWORK_TOKEN_URL
+        ? { data: { access_token: 'tok-1', expires_in: 3600 } }
+        : { data: { data: { marketplaceJobPostings: { edges: [{ node: { id: 'a' } }] } } } };
+
+    const data = await executeUpworkGraphql<any>(tokens(), { query: 'q' });
+    expect(data.marketplaceJobPostings.edges).toHaveLength(1);
+  });
+
+  it('throws on in-band GraphQL errors even though HTTP is 200', async () => {
+    // 🛑 The check that a status-code-only implementation would miss.
+    nextResponse = (url) =>
+      url === UPWORK_TOKEN_URL
+        ? { data: { access_token: 'tok-1', expires_in: 3600 } }
+        : { data: { errors: [{ message: 'field X not found' }] } };
+
+    await expect(
+      executeUpworkGraphql(tokens(), { query: 'q' }),
+    ).rejects.toThrow(/field X not found/);
+  });
+
+  it('refreshes once and retries on 401, then succeeds', async () => {
+    let gqlCalls = 0;
+    nextResponse = (url) => {
+      if (url === UPWORK_TOKEN_URL) {
+        return { data: { access_token: `tok-${posts.filter((p) => p.url === UPWORK_TOKEN_URL).length}`, expires_in: 3600 } };
+      }
+      gqlCalls += 1;
+      if (gqlCalls === 1) {
+        throw Object.assign(new Error('unauthorized'), {
+          response: { status: 401 },
+        });
+      }
+      return { data: { data: { ok: true } } };
+    };
+
+    const data = await executeUpworkGraphql<any>(tokens(), { query: 'q' });
+    expect(data).toEqual({ ok: true });
+    expect(gqlCalls).toBe(2);
+    // Exactly two token requests: the initial one and the forced refresh.
+    expect(posts.filter((p) => p.url === UPWORK_TOKEN_URL)).toHaveLength(2);
+  });
+
+  it('does not retry non-401 failures', async () => {
+    let gqlCalls = 0;
+    nextResponse = (url) => {
+      if (url === UPWORK_TOKEN_URL) {
+        return { data: { access_token: 'tok-1', expires_in: 3600 } };
+      }
+      gqlCalls += 1;
+      throw Object.assign(new Error('server error'), {
+        response: { status: 500 },
+      });
+    };
+
+    await expect(
+      executeUpworkGraphql(tokens(), { query: 'q' }),
+    ).rejects.toThrow(UpworkApiError);
+    expect(gqlCalls).toBe(1);
+  });
+});

--- a/packages/plugins/source-upwork/src/index.ts
+++ b/packages/plugins/source-upwork/src/index.ts
@@ -1,2 +1,11 @@
 export { UpworkService } from './upwork.service';
 export { UpworkModule } from './upwork.module';
+export {
+  UpworkTokenProvider,
+  executeUpworkGraphql,
+  UpworkApiError,
+} from './upwork.client';
+export type {
+  UpworkTokenResponse,
+  UpworkGraphqlRequest,
+} from './upwork.client';

--- a/packages/plugins/source-upwork/src/upwork.client.ts
+++ b/packages/plugins/source-upwork/src/upwork.client.ts
@@ -1,0 +1,270 @@
+import { Logger } from '@nestjs/common';
+import { UpworkAuthDto, UpworkGrantType } from '@ever-jobs/models';
+import { createHttpClient } from '@ever-jobs/common';
+
+import {
+  UPWORK_TOKEN_URL,
+  UPWORK_GRAPHQL_URL,
+  UPWORK_TOKEN_EXPIRY_SKEW_SECONDS,
+  UPWORK_DEFAULT_TIMEOUT_SECONDS,
+} from './upwork.constants';
+
+/**
+ * Direct Upwork OAuth2 + GraphQL client.
+ *
+ * ## Why this exists
+ *
+ * This replaces `@upwork/node-upwork-oauth2`. That SDK's latest release (2.3.0,
+ * published 2024-11-27) still pins `request@2.88.2` — a deprecated HTTP stack
+ * whose advisories have **no upstream fix** (`request` SSRF GHSA-p8p7-x288-28g6,
+ * `tough-cookie` prototype pollution GHSA-72xf-g2v4-qvf3, `uuid` buffer bounds
+ * GHSA-w5hq-g745-h8pq). There is no clean version to upgrade to.
+ *
+ * Forking and republishing it was considered and rejected: the plugin only ever
+ * used three things from the SDK — construct a client, obtain a token, POST one
+ * GraphQL document. Reimplementing those here **removes** a dependency instead
+ * of adopting one, and reuses `createHttpClient` so Upwork inherits the same
+ * timeout / retry / proxy handling as every other source.
+ *
+ * ## Wire compatibility
+ *
+ * Endpoints and semantics are transcribed from the SDK so behaviour is
+ * unchanged:
+ *   - `client_credentials` → POST {@link UPWORK_TOKEN_URL} (SDK: `Client.getToken`
+ *     → `simple-oauth2` `ClientCredentials.getToken()`).
+ *   - `authorization_code` → the caller supplies an access/refresh pair; we
+ *     refresh via `grant_type=refresh_token` only when the token is expired
+ *     (SDK: `Client.setAccessToken`, which refreshes only on `aToken.expired()`).
+ *   - GraphQL → POST {@link UPWORK_GRAPHQL_URL} with `Authorization: Bearer`,
+ *     `Content-Type: application/json`, body `{query, variables}` (SDK:
+ *     `Client.post` with `entryPoint === 'graphql'`).
+ *
+ * 🛑 Client credentials are sent in the **request body**, not as an
+ * `Authorization: Basic` header — the SDK sets simple-oauth2's
+ * `authorizationMethod: 'body'`. Using Basic auth here returns 401.
+ */
+
+/** Shape of a successful Upwork token response. */
+export interface UpworkTokenResponse {
+  access_token: string;
+  refresh_token?: string;
+  token_type?: string;
+  /** Lifetime in seconds, as returned by the token endpoint. */
+  expires_in?: number;
+}
+
+/** A GraphQL request, matching what the SDK's `Graphql.execute` accepted. */
+export interface UpworkGraphqlRequest {
+  query: string;
+  /**
+   * Upwork expects `variables` as a JSON **string**, which is what the existing
+   * caller already passes. Objects are serialised here so both forms work.
+   */
+  variables?: string | Record<string, unknown>;
+}
+
+/** Thrown for any non-2xx or GraphQL-level failure, so callers see one type. */
+export class UpworkApiError extends Error {
+  constructor(
+    message: string,
+    readonly status?: number,
+  ) {
+    super(message);
+    this.name = 'UpworkApiError';
+  }
+}
+
+/**
+ * Obtains and caches an Upwork access token.
+ *
+ * One instance per credential set. Tokens are cached in memory and reused until
+ * they are within {@link UPWORK_TOKEN_EXPIRY_SKEW_SECONDS} of expiry, so a
+ * fan-out of searches costs one token request rather than one per search.
+ */
+export class UpworkTokenProvider {
+  private readonly logger = new Logger(UpworkTokenProvider.name);
+  private readonly http = createHttpClient({
+    timeout: UPWORK_DEFAULT_TIMEOUT_SECONDS,
+  });
+
+  private cachedToken?: string;
+  /** Epoch ms at which {@link cachedToken} should no longer be used. */
+  private cachedExpiresAt = 0;
+  private refreshToken?: string;
+
+  constructor(
+    private readonly auth: UpworkAuthDto,
+    private readonly grantType: UpworkGrantType,
+  ) {
+    this.refreshToken = auth.refreshToken;
+    // An caller-supplied access token is usable immediately. We do not know its
+    // expiry, so treat it as valid until Upwork rejects it — the SDK behaved the
+    // same way when `expiresAt` was absent.
+    if (grantType === UpworkGrantType.AUTHORIZATION_CODE && auth.accessToken) {
+      this.cachedToken = auth.accessToken;
+      this.cachedExpiresAt = Number.POSITIVE_INFINITY;
+    }
+  }
+
+  /** `true` once the cached token is missing or within the expiry skew. */
+  private get needsToken(): boolean {
+    if (!this.cachedToken) return true;
+    return Date.now() >= this.cachedExpiresAt;
+  }
+
+  /**
+   * Return a usable access token, obtaining or refreshing one if required.
+   *
+   * @param force re-fetch even if a cached token looks valid. Used after a 401,
+   *   which is the only reliable signal that a token with unknown expiry died.
+   */
+  async getAccessToken(force = false): Promise<string> {
+    if (!force && !this.needsToken && this.cachedToken) {
+      return this.cachedToken;
+    }
+
+    const token =
+      this.grantType === UpworkGrantType.CLIENT_CREDENTIALS
+        ? await this.requestToken({ grant_type: 'client_credentials' })
+        : await this.refreshAccessToken();
+
+    this.cachedToken = token.access_token;
+    if (token.refresh_token) this.refreshToken = token.refresh_token;
+    this.cachedExpiresAt = token.expires_in
+      ? Date.now() +
+        (token.expires_in - UPWORK_TOKEN_EXPIRY_SKEW_SECONDS) * 1000
+      : Number.POSITIVE_INFINITY;
+
+    return this.cachedToken;
+  }
+
+  /** Exchange the refresh token for a fresh access token. */
+  private async refreshAccessToken(): Promise<UpworkTokenResponse> {
+    if (!this.refreshToken) {
+      throw new UpworkApiError(
+        'Upwork authorization_code grant requires a refreshToken to obtain a new access token',
+      );
+    }
+    return this.requestToken({
+      grant_type: 'refresh_token',
+      refresh_token: this.refreshToken,
+    });
+  }
+
+  /**
+   * POST the token endpoint.
+   *
+   * 🛑 `client_id` / `client_secret` go in the BODY — see
+   * `UPWORK_AUTHORIZATION_METHOD`.
+   */
+  private async requestToken(
+    params: Record<string, string>,
+  ): Promise<UpworkTokenResponse> {
+    const body = new URLSearchParams({
+      ...params,
+      client_id: this.auth.clientId ?? '',
+      client_secret: this.auth.clientSecret ?? '',
+    });
+
+    try {
+      const res = await this.http.post<UpworkTokenResponse>(
+        UPWORK_TOKEN_URL,
+        body.toString(),
+        {
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        },
+      );
+      const data = res.data;
+      if (!data?.access_token) {
+        throw new UpworkApiError(
+          `Upwork token endpoint returned no access_token (grant_type=${params.grant_type})`,
+        );
+      }
+      return data;
+    } catch (err: unknown) {
+      if (err instanceof UpworkApiError) throw err;
+      // Never echo the response body — a failed token exchange can reflect the
+      // submitted client_secret back in the error payload.
+      const status = (err as { response?: { status?: number } })?.response
+        ?.status;
+      throw new UpworkApiError(
+        `Upwork token request failed (grant_type=${params.grant_type})${
+          status ? ` with HTTP ${status}` : ''
+        }`,
+        status,
+      );
+    }
+  }
+
+  /** Test seam: drop any cached token. */
+  reset(): void {
+    this.cachedToken = undefined;
+    this.cachedExpiresAt = 0;
+  }
+}
+
+/**
+ * Execute one GraphQL document against the Upwork API.
+ *
+ * Retries exactly once on 401 with a forced token refresh — an access token
+ * supplied by the caller has unknown expiry, so a 401 is the only reliable
+ * signal that it died. Any other failure surfaces as {@link UpworkApiError}.
+ */
+export async function executeUpworkGraphql<T = unknown>(
+  tokens: UpworkTokenProvider,
+  request: UpworkGraphqlRequest,
+  logger?: Logger,
+): Promise<T> {
+  const http = createHttpClient({ timeout: UPWORK_DEFAULT_TIMEOUT_SECONDS });
+
+  const body = {
+    query: request.query,
+    variables:
+      typeof request.variables === 'string'
+        ? request.variables
+        : JSON.stringify(request.variables ?? {}),
+  };
+
+  const send = async (token: string) =>
+    http.post<{ data?: T; errors?: { message?: string }[] }>(
+      UPWORK_GRAPHQL_URL,
+      body,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+
+  let res;
+  try {
+    res = await send(await tokens.getAccessToken());
+  } catch (err: unknown) {
+    const status = (err as { response?: { status?: number } })?.response
+      ?.status;
+    if (status !== 401) {
+      throw new UpworkApiError(
+        `Upwork GraphQL request failed${status ? ` with HTTP ${status}` : ''}`,
+        status,
+      );
+    }
+    logger?.warn('Upwork access token rejected (401) — refreshing and retrying');
+    res = await send(await tokens.getAccessToken(true));
+  }
+
+  const payload = res.data;
+
+  // GraphQL reports failures in-band with HTTP 200, so this check is required
+  // and is NOT redundant with the status handling above.
+  if (payload?.errors?.length) {
+    const first = payload.errors[0]?.message ?? 'unknown GraphQL error';
+    throw new UpworkApiError(
+      `Upwork GraphQL error: ${first}${
+        payload.errors.length > 1 ? ` (+${payload.errors.length - 1} more)` : ''
+      }`,
+    );
+  }
+
+  return payload?.data as T;
+}

--- a/packages/plugins/source-upwork/src/upwork.constants.ts
+++ b/packages/plugins/source-upwork/src/upwork.constants.ts
@@ -71,3 +71,38 @@ export const JOB_SEARCH_QUERY = `
     }
   }
 `;
+
+// ── OAuth2 / GraphQL endpoints ──────────────────────────────
+//
+// Transcribed from `@upwork/node-upwork-oauth2@2.3.0` (`lib/config.js`) so the
+// direct client below is wire-compatible with the SDK it replaces. The SDK is
+// NOT a dependency — its latest release (2.3.0, 2024-11-27) still pins
+// `request@2.88.2`, whose advisories have no upstream fix.
+
+/** OAuth2 token host — `Config.tokenHost` in the SDK. */
+export const UPWORK_TOKEN_HOST = 'https://www.upwork.com';
+
+/** OAuth2 token path — `Config.tokenPath` in the SDK. */
+export const UPWORK_TOKEN_PATH = '/api/v3/oauth2/token';
+
+/** Full token endpoint. */
+export const UPWORK_TOKEN_URL = `${UPWORK_TOKEN_HOST}${UPWORK_TOKEN_PATH}`;
+
+/** GraphQL endpoint — `Config.gqlUrl` in the SDK. */
+export const UPWORK_GRAPHQL_URL = 'https://api.upwork.com/graphql';
+
+/**
+ * 🛑 Credentials go in the request BODY, not an `Authorization: Basic` header.
+ *
+ * The SDK configures simple-oauth2 with `options.authorizationMethod = 'body'`
+ * (`lib/client.js`). Upwork's token endpoint is built around that, so sending
+ * Basic auth instead yields 401 — this is the single easiest thing to get wrong
+ * when replacing the SDK, hence the constant rather than an inline literal.
+ */
+export const UPWORK_AUTHORIZATION_METHOD = 'body' as const;
+
+/** Seconds of slack applied before treating an access token as expired. */
+export const UPWORK_TOKEN_EXPIRY_SKEW_SECONDS = 60;
+
+/** Default request timeout (seconds) for token + GraphQL calls. */
+export const UPWORK_DEFAULT_TIMEOUT_SECONDS = 30;

--- a/packages/plugins/source-upwork/src/upwork.service.ts
+++ b/packages/plugins/source-upwork/src/upwork.service.ts
@@ -24,30 +24,20 @@ import {
   DEFAULT_NUM_RESULTS,
   DEFAULT_SORT_FIELD,
 } from './upwork.constants';
-
-// The Upwork SDK (`@upwork/node-upwork-oauth2`) pulls in the deprecated `request`
-// stack (request/tough-cookie/uuid) with unpatchable advisories. This fork does
-// not use Upwork, so the dependency is removed from package.json and the SDK is
-// loaded lazily — only if a caller actually configures Upwork credentials.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function loadUpworkSdk(): { UpworkApi: any; Graphql: any } {
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const UpworkApi = require('@upwork/node-upwork-oauth2');
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { Graphql } = require('@upwork/node-upwork-oauth2/lib/routers/graphql');
-    return { UpworkApi, Graphql };
-  } catch {
-    throw new Error(
-      'Upwork source is disabled in this fork: the @upwork/node-upwork-oauth2 ' +
-        'dependency was removed for security (deprecated request/tough-cookie/uuid). ' +
-        'Reinstall it to re-enable Upwork.',
-    );
-  }
-}
+import {
+  UpworkTokenProvider,
+  executeUpworkGraphql,
+  UpworkApiError,
+} from './upwork.client';
 
 /**
- * Upwork job search service using the official Upwork Node.js SDK.
+ * Upwork job search service.
+ *
+ * Talks to Upwork's OAuth2 + GraphQL endpoints directly via
+ * {@link UpworkTokenProvider} / {@link executeUpworkGraphql}. The official
+ * `@upwork/node-upwork-oauth2` SDK is deliberately NOT used: its latest
+ * release (2.3.0, 2024-11-27) still pins `request@2.88.2`, whose advisories
+ * have no upstream fix. See `upwork.client.ts` for the full rationale.
  *
  * Supports two OAuth2 grant types:
  *   - `client_credentials`  — server-to-server (clientId + clientSecret only)
@@ -71,7 +61,7 @@ function loadUpworkSdk(): { UpworkApi: any; Graphql: any } {
 @Injectable()
 export class UpworkService implements IScraper {
   private readonly logger = new Logger(UpworkService.name);
-  private defaultApi: any;
+  private defaultTokens?: UpworkTokenProvider;
   private defaultIsConfigured = false;
   private defaultGrantType: UpworkGrantType = UpworkGrantType.CLIENT_CREDENTIALS;
 
@@ -79,12 +69,16 @@ export class UpworkService implements IScraper {
     const envAuth = this.readEnvAuth();
     if (envAuth) {
       try {
-        this.defaultApi = this.createApiClient(envAuth);
         this.defaultGrantType = this.inferGrantType(envAuth);
+        this.defaultTokens = new UpworkTokenProvider(
+          envAuth,
+          this.defaultGrantType,
+        );
         this.defaultIsConfigured = true;
       } catch (err: any) {
-        // SDK not installed in this fork — degrade instead of crashing DI startup.
-        this.logger.warn(err.message);
+        // Never let a credential problem crash DI startup — degrade to "no
+        // Upwork" exactly as an unconfigured deployment does.
+        this.logger.warn(`Upwork credentials rejected at startup: ${err.message}`);
       }
     } else {
       this.logger.warn(
@@ -98,9 +92,9 @@ export class UpworkService implements IScraper {
   }
 
   async scrape(input: ScraperInputDto): Promise<JobResponseDto> {
-    const { api, grantType } = this.resolveApi(input);
+    const { tokens, grantType } = this.resolveTokens(input);
 
-    if (!api) {
+    if (!tokens) {
       this.logger.warn('Skipping Upwork scrape — no credentials available');
       return new JobResponseDto([]);
     }
@@ -113,29 +107,25 @@ export class UpworkService implements IScraper {
     );
 
     try {
-      // Authenticate based on grant type
-      if (grantType === UpworkGrantType.CLIENT_CREDENTIALS) {
-        await this.obtainClientCredentialsToken(api);
-      } else {
-        await this.setAccessToken(api);
-      }
-
-      const { Graphql } = loadUpworkSdk();
-      const graphql = new Graphql(api);
-
+      // The token provider handles both grants and caches the result, so a
+      // fan-out of searches costs one token request rather than one per search.
       const variables = {
         searchTerm: searchTerm || '',
         first: numResults,
         sortField: DEFAULT_SORT_FIELD,
       };
 
-      const data = await this.executeGraphql(graphql, {
-        query: JOB_SEARCH_QUERY,
-        variables: JSON.stringify(variables),
-      });
+      const data = await executeUpworkGraphql<{
+        marketplaceJobPostings?: { edges?: { node: any }[] };
+      }>(
+        tokens,
+        { query: JOB_SEARCH_QUERY, variables: JSON.stringify(variables) },
+        this.logger,
+      );
 
-      const edges =
-        data?.data?.marketplaceJobPostings?.edges ?? [];
+      // `executeUpworkGraphql` already unwraps the GraphQL envelope's `data`,
+      // so this reads one level shallower than the SDK path did.
+      const edges = data?.marketplaceJobPostings?.edges ?? [];
       this.logger.log(`Upwork returned ${edges.length} results`);
 
       const jobs: JobPostDto[] = [];
@@ -151,7 +141,20 @@ export class UpworkService implements IScraper {
 
       return new JobResponseDto(jobs);
     } catch (err: any) {
-      this.logger.error(`Upwork scrape error: ${err.message}`);
+      // Distinguish "Upwork said no" from an unexpected fault. A 401 here means
+      // the credentials are wrong or revoked (the client already retried once
+      // with a refreshed token), which is operator-actionable; anything else is
+      // a bug or a transient network failure.
+      if (err instanceof UpworkApiError) {
+        this.logger.error(
+          err.status === 401
+            ? 'Upwork rejected the credentials (HTTP 401) even after refreshing — check UPWORK_CLIENT_ID/SECRET and any refresh token'
+            : `Upwork API error: ${err.message}`,
+        );
+      } else {
+        this.logger.error(`Upwork scrape error: ${err.message}`);
+      }
+      // Graceful degradation: a failing source must never fail the fan-out.
       return new JobResponseDto([]);
     }
   }
@@ -188,23 +191,28 @@ export class UpworkService implements IScraper {
   }
 
   /**
-   * Resolve which API client and grant type to use for this request.
+   * Resolve which token provider and grant type to use for this request.
    * Per-request auth (`input.auth.upwork`) takes precedence over env-var defaults.
+   *
+   * A per-request provider is built fresh each time (credentials differ per
+   * caller); the env-var provider is a singleton so its token cache is shared.
    */
-  private resolveApi(input: ScraperInputDto): { api: any; grantType: UpworkGrantType } {
+  private resolveTokens(input: ScraperInputDto): {
+    tokens: UpworkTokenProvider | null;
+    grantType: UpworkGrantType;
+  } {
     const requestAuth = input.auth?.upwork;
 
     if (requestAuth?.clientId && requestAuth?.clientSecret) {
       const grantType = this.inferGrantType(requestAuth);
-      const api = this.createApiClient(requestAuth);
-      return { api, grantType };
+      return { tokens: new UpworkTokenProvider(requestAuth, grantType), grantType };
     }
 
-    if (this.defaultIsConfigured && this.defaultApi) {
-      return { api: this.defaultApi, grantType: this.defaultGrantType };
+    if (this.defaultIsConfigured && this.defaultTokens) {
+      return { tokens: this.defaultTokens, grantType: this.defaultGrantType };
     }
 
-    return { api: null, grantType: UpworkGrantType.CLIENT_CREDENTIALS };
+    return { tokens: null, grantType: UpworkGrantType.CLIENT_CREDENTIALS };
   }
 
   /**
@@ -220,81 +228,6 @@ export class UpworkService implements IScraper {
     return (auth.accessToken && auth.refreshToken)
       ? UpworkGrantType.AUTHORIZATION_CODE
       : UpworkGrantType.CLIENT_CREDENTIALS;
-  }
-
-  /**
-   * Create a new UpworkApi SDK instance from auth credentials.
-   */
-  private createApiClient(auth: UpworkAuthDto): any {
-    const grantType = this.inferGrantType(auth);
-    const config: any = {
-      clientId: auth.clientId,
-      clientSecret: auth.clientSecret,
-    };
-
-    if (grantType === UpworkGrantType.CLIENT_CREDENTIALS) {
-      config.grantType = 'client_credentials';
-    } else {
-      config.accessToken = auth.accessToken;
-      config.refreshToken = auth.refreshToken;
-    }
-
-    const { UpworkApi } = loadUpworkSdk();
-    return new UpworkApi(config);
-  }
-
-  /**
-   * Obtain an access token via the client_credentials grant.
-   */
-  private obtainClientCredentialsToken(api: any): Promise<any> {
-    return new Promise((resolve, reject) => {
-      api.getToken(null, (error: any, tokenPair: any) => {
-        if (error) {
-          reject(new Error(`Upwork client_credentials token failed: ${error}`));
-        } else {
-          resolve(tokenPair);
-        }
-      });
-    });
-  }
-
-  /**
-   * Set up access token on the API instance (authorization_code flow).
-   * The SDK automatically refreshes expired tokens.
-   */
-  private setAccessToken(api: any): Promise<any> {
-    return new Promise((resolve, reject) => {
-      api.setAccessToken((error: any, tokenPair: any) => {
-        if (error) {
-          reject(new Error(`Upwork token setup failed: ${error}`));
-        } else {
-          resolve(tokenPair);
-        }
-      });
-    });
-  }
-
-  // ── GraphQL ───────────────────────────────────────────────
-
-  /**
-   * Execute a GraphQL request via the Upwork SDK.
-   */
-  private executeGraphql(graphql: any, params: any): Promise<any> {
-    return new Promise((resolve, reject) => {
-      graphql.execute(params, (error: any, httpStatus: number, data: any) => {
-        if (error) {
-          reject(new Error(`Upwork GraphQL error: ${error}`));
-        } else if (httpStatus >= 400) {
-          reject(
-            new Error(
-              `Upwork API returned HTTP ${httpStatus}: ${JSON.stringify(data)}`,
-            ),
-          );
-        } else {
-          resolve(data);
-        }
-      });
-    });
   }
 
   // ── Result processing ─────────────────────────────────────


### PR DESCRIPTION
Completes the `develop → stage → main` cascade of #50 / #51.

The Upwork source is restored via a direct OAuth2 + GraphQL client inside the plugin — **zero new dependencies**, and the vulnerable `request` tree stays gone.

Verified: `tsc` clean, 15/15 tests (both load-bearing assertions mutation-checked), and all four CI build steps reproduced locally with the exact commands.

**Inert unless configured:** no `UPWORK_*` credentials exist in prod, stage or dev, so `scrape()` continues to return `[]` with a warning until someone provisions them.