### PR TITLE
fix(common): redact credential query params from HttpClient retry logs

### DIFF
--- a/packages/common/__tests__/http-client.spec.ts
+++ b/packages/common/__tests__/http-client.spec.ts
@@ -21,10 +21,10 @@ function httpError(status: number, headers: Record<string, string> = {}): Error 
 }
 
 /**
- * Spec 5084 — a retry log line that does not name its own request cannot be
+ * Spec 5085 — a retry log line that does not name its own request cannot be
  * attributed to anything, and a 429 must honor the pause the server asked for.
  */
-describe('HttpClient retry attribution and Retry-After — Spec 5084', () => {
+describe('HttpClient retry attribution and Retry-After — Spec 5085', () => {
   beforeEach(() => {
     mockAxiosRequest.mockReset();
     jest.useFakeTimers();
@@ -105,5 +105,71 @@ describe('HttpClient retry attribution and Retry-After — Spec 5084', () => {
     await run(client.get('https://acme.example.com/api'));
 
     expect(logger.mock.calls[0][0]).toContain('in 1500ms');
+  });
+});
+
+/**
+ * Naming the request made the retry line attributable, but several sources
+ * authenticate by query parameter, so the same line would have written their
+ * credentials into the logs.
+ */
+describe('HttpClient retry log URL redaction', () => {
+  beforeEach(() => {
+    mockAxiosRequest.mockReset();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  /** Retry once against `url` and return the warn line it logged. */
+  async function warnLineFor(url: string): Promise<string> {
+    const client = new HttpClient({ retries: 1 });
+    const logger = jest.spyOn((client as any).logger, 'warn').mockImplementation(() => undefined);
+    mockAxiosRequest
+      .mockRejectedValueOnce(httpError(429))
+      .mockResolvedValueOnce({ data: 'ok' });
+
+    const settled = client.get(url).catch((err: Error) => err);
+    await jest.advanceTimersByTimeAsync(60_000);
+    await settled;
+
+    return logger.mock.calls[0][0] as string;
+  }
+
+  it.each([
+    ['api_key', 'https://api.ceipal.com/getJobPostings?api_key=SECRET-VALUE'],
+    ['apikey', 'https://api.resumatorapi.com/v1/jobs?apikey=SECRET-VALUE'],
+    ['token', 'https://api.comeet.co/careers/v1/positions?token=SECRET-VALUE'],
+    ['access_token', 'https://acme.example.com/v1/jobs?access_token=SECRET-VALUE'],
+  ])('redacts a %s query parameter', async (key, url) => {
+    const line = await warnLineFor(url);
+
+    expect(line).not.toContain('SECRET-VALUE');
+    expect(line).toContain(`${key}=REDACTED`);
+  });
+
+  it('keeps the non-credential parameters that make the line attributable', async () => {
+    const line = await warnLineFor(
+      'https://api.ceipal.com/getJobPostings?company=acme&api_key=SECRET-VALUE&page=3',
+    );
+
+    expect(line).not.toContain('SECRET-VALUE');
+    expect(line).toContain('https://api.ceipal.com/getJobPostings?company=acme&api_key=REDACTED&page=3');
+  });
+
+  it('leaves a URL without a query string untouched', async () => {
+    const line = await warnLineFor('https://acme.example.com/wday/cxs/acme/Careers/job/R-1');
+
+    expect(line).toContain('GET https://acme.example.com/wday/cxs/acme/Careers/job/R-1 failed 429');
+  });
+
+  it('preserves the fragment while redacting the query', async () => {
+    const line = await warnLineFor('https://acme.example.com/jobs?token=SECRET-VALUE#results');
+
+    expect(line).not.toContain('SECRET-VALUE');
+    expect(line).toContain('https://acme.example.com/jobs?token=REDACTED#results');
   });
 });

--- a/packages/common/__tests__/http-client.spec.ts
+++ b/packages/common/__tests__/http-client.spec.ts
@@ -140,9 +140,9 @@ describe('HttpClient retry log URL redaction', () => {
   }
 
   it.each([
-    ['api_key', 'https://api.ceipal.com/getJobPostings?api_key=SECRET-VALUE'],
     ['apikey', 'https://api.resumatorapi.com/v1/jobs?apikey=SECRET-VALUE'],
     ['token', 'https://api.comeet.co/careers/v1/positions?token=SECRET-VALUE'],
+    ['api_key', 'https://api.example-ats.com/v1/jobs?api_key=SECRET-VALUE'],
     ['access_token', 'https://acme.example.com/v1/jobs?access_token=SECRET-VALUE'],
   ])('redacts a %s query parameter', async (key, url) => {
     const line = await warnLineFor(url);
@@ -153,11 +153,11 @@ describe('HttpClient retry log URL redaction', () => {
 
   it('keeps the non-credential parameters that make the line attributable', async () => {
     const line = await warnLineFor(
-      'https://api.ceipal.com/getJobPostings?company=acme&api_key=SECRET-VALUE&page=3',
+      'https://api.resumatorapi.com/v1/jobs?company=acme&apikey=SECRET-VALUE&page=3',
     );
 
     expect(line).not.toContain('SECRET-VALUE');
-    expect(line).toContain('https://api.ceipal.com/getJobPostings?company=acme&api_key=REDACTED&page=3');
+    expect(line).toContain('https://api.resumatorapi.com/v1/jobs?company=acme&apikey=REDACTED&page=3');
   });
 
   it('leaves a URL without a query string untouched', async () => {
@@ -171,5 +171,44 @@ describe('HttpClient retry log URL redaction', () => {
 
     expect(line).not.toContain('SECRET-VALUE');
     expect(line).toContain('https://acme.example.com/jobs?token=REDACTED#results');
+  });
+
+  /**
+   * Ceipal carries the tenant key as the first path segment rather than a query
+   * parameter (`CeipalService.fetchListPage` builds
+   * `https://api.ceipal.com/{apiKey}/job-postings/`), and the service masks it
+   * in its own logs — the shared retry line must not undo that.
+   */
+  it('redacts the Ceipal tenant key carried as a path segment', async () => {
+    const line = await warnLineFor('https://api.ceipal.com/deadbeefkey/job-postings/');
+
+    expect(line).not.toContain('deadbeefkey');
+    expect(line).toContain('https://api.ceipal.com/REDACTED/job-postings/');
+  });
+
+  it('redacts a Ceipal path key alongside a query string', async () => {
+    const line = await warnLineFor('https://api.ceipal.com/deadbeefkey/job-postings/?page=2');
+
+    expect(line).not.toContain('deadbeefkey');
+    expect(line).toContain('https://api.ceipal.com/REDACTED/job-postings/?page=2');
+  });
+
+  it('leaves the first path segment of every other host alone', async () => {
+    const line = await warnLineFor('https://boards.greenhouse.io/acme/jobs/42');
+
+    expect(line).toContain('https://boards.greenhouse.io/acme/jobs/42');
+  });
+
+  it('redacts the Ceipal key when the URL carries a port', async () => {
+    const line = await warnLineFor('https://api.ceipal.com:443/deadbeefkey/job-postings/');
+
+    expect(line).not.toContain('deadbeefkey');
+    expect(line).toContain('https://api.ceipal.com:443/REDACTED/job-postings/');
+  });
+
+  it('leaves a bare Ceipal origin with no key alone', async () => {
+    const line = await warnLineFor('https://api.ceipal.com/');
+
+    expect(line).toContain('GET https://api.ceipal.com/ failed 429');
   });
 });

--- a/packages/common/src/http/http-client.ts
+++ b/packages/common/src/http/http-client.ts
@@ -17,6 +17,22 @@ const RETRYABLE_STATUSES = [429, 500, 502, 503, 504];
 const SENSITIVE_QUERY_KEYS =
   /^(?:api[-_]?key|access[-_]?token|token|secret|password|passwd|pwd|auth|authorization|signature|sig|session|credentials?)$/i;
 
+/**
+ * Hosts that carry a credential in the URL *path* rather than the query string,
+ * mapped to the zero-based index of the offending path segment. Ceipal routes
+ * every tenant call through `https://api.ceipal.com/{apiKey}/job-postings/`, so
+ * the first segment is the tenant's career-portal key — `CeipalService` already
+ * masks it in its own logs (`maskKey`), and the shared retry line must not undo
+ * that. `source-ats-ceipal` is currently the only plugin that builds a URL this
+ * way; add a row here if another one appears.
+ */
+const SENSITIVE_PATH_SEGMENTS: Record<string, number> = {
+  'api.ceipal.com': 0,
+};
+
+/** Scheme + authority of an absolute URL, e.g. `https://api.ceipal.com:443`. */
+const URL_AUTHORITY = /^[a-z][a-z0-9+.-]*:\/\/([^/?#]*)/i;
+
 export interface HttpClientOptions {
   proxies?: string[];
   caCert?: string;
@@ -183,13 +199,49 @@ export class HttpClient {
   }
 
   /**
-   * Replace the value of every credential-bearing query parameter with
-   * `REDACTED`, leaving the rest of the URL intact so the line still names its
-   * target. Splits on delimiters rather than parsing, so a relative URL or a
-   * malformed query degrades to "unchanged" instead of throwing inside a
-   * logging path.
+   * Strip credentials out of a URL before it reaches a log line, leaving the
+   * rest intact so the message still names its target. Splits on delimiters
+   * rather than parsing, so a relative or malformed URL degrades to "unchanged"
+   * instead of throwing inside a logging path.
    */
   private redactUrl(url: string): string {
+    return this.redactQuery(this.redactPathCredential(url));
+  }
+
+  /**
+   * Replace a credential carried as a path segment (see
+   * `SENSITIVE_PATH_SEGMENTS`) with `REDACTED`. Relative URLs and hosts with no
+   * rule are returned unchanged.
+   */
+  private redactPathCredential(url: string): string {
+    const authority = URL_AUTHORITY.exec(url);
+    if (!authority) return url;
+
+    const host = authority[1].replace(/^.*@/, '').replace(/:\d+$/, '').toLowerCase();
+    const index = SENSITIVE_PATH_SEGMENTS[host];
+    if (index === undefined) return url;
+
+    const pathStart = authority[0].length;
+    const query = url.indexOf('?', pathStart);
+    const fragment = url.indexOf('#', pathStart);
+    const ends = [query, fragment].filter((i) => i !== -1);
+    const pathEnd = ends.length ? Math.min(...ends) : url.length;
+
+    // A path that starts with `/` splits to a leading empty segment, so the
+    // first real segment is at index 1.
+    const segments = url.slice(pathStart, pathEnd).split('/');
+    const target = index + 1;
+    if (target >= segments.length || !segments[target]) return url;
+
+    segments[target] = 'REDACTED';
+    return url.slice(0, pathStart) + segments.join('/') + url.slice(pathEnd);
+  }
+
+  /**
+   * Replace the value of every credential-bearing query parameter with
+   * `REDACTED`.
+   */
+  private redactQuery(url: string): string {
     const start = url.indexOf('?');
     if (start === -1) return url;
 

--- a/packages/common/src/http/http-client.ts
+++ b/packages/common/src/http/http-client.ts
@@ -7,6 +7,16 @@ import { getRequestId } from '../context';
 
 const RETRYABLE_STATUSES = [429, 500, 502, 503, 504];
 
+/**
+ * Query-string keys whose values must never reach a log line. Several sources
+ * authenticate by query parameter (`source-ats-ceipal` `api_key`,
+ * `source-ats-jazzhr` `apikey`, `source-ats-teamtailor` / `source-ats-talentera`
+ * / `source-ats-comeet` `token`), so naming the raw URL on retry would copy
+ * those credentials into the pod logs.
+ */
+const SENSITIVE_QUERY_KEYS =
+  /^(?:api[-_]?key|access[-_]?token|token|secret|password|passwd|pwd|auth|authorization|signature|sig|session|credentials?)$/i;
+
 export interface HttpClientOptions {
   proxies?: string[];
   caCert?: string;
@@ -167,9 +177,35 @@ export class HttpClient {
    */
   private describeRequest(config: AxiosRequestConfig): string {
     const method = (config.method ?? 'GET').toUpperCase();
-    const url = config.url ?? '(no url)';
+    const url = config.url ? this.redactUrl(config.url) : '(no url)';
     const requestId = getRequestId();
     return requestId ? `[${requestId}] ${method} ${url}` : `${method} ${url}`;
+  }
+
+  /**
+   * Replace the value of every credential-bearing query parameter with
+   * `REDACTED`, leaving the rest of the URL intact so the line still names its
+   * target. Splits on delimiters rather than parsing, so a relative URL or a
+   * malformed query degrades to "unchanged" instead of throwing inside a
+   * logging path.
+   */
+  private redactUrl(url: string): string {
+    const start = url.indexOf('?');
+    if (start === -1) return url;
+
+    const [query, ...fragment] = url.slice(start + 1).split('#');
+    const redacted = query
+      .split('&')
+      .map((pair) => {
+        const eq = pair.indexOf('=');
+        if (eq === -1) return pair;
+        const key = pair.slice(0, eq);
+        return SENSITIVE_QUERY_KEYS.test(key) ? `${key}=REDACTED` : pair;
+      })
+      .join('&');
+
+    const hash = fragment.length ? `#${fragment.join('#')}` : '';
+    return `${url.slice(0, start)}?${redacted}${hash}`;
   }
 
   /** `Retry-After` as milliseconds: delta-seconds or an HTTP-date. Null when absent/unparseable. */


### PR DESCRIPTION
## Why

Spec 5085 (merged in #53) made the `HttpClient` retry warn line name its own request — `GET <url> failed 429, retry 1/3 in 1000ms` — which is what made it attributable across a concurrency-64 fan-out.

But several sources authenticate through the URL, so the same line copied live credentials into the pod logs:

| Source | Where the credential sits |
|---|---|
| `source-ats-ceipal` | **path** — `https://api.ceipal.com/{apiKey}/job-postings/` |
| `source-ats-jazzhr` | query — `apikey=` |
| `source-ats-teamtailor` | query — `token=` |
| `source-ats-talentera` | query — `token=` |
| `source-ats-comeet` | query — `token=` |

The previous line logged only the status code, so this exposure arrived with the attribution change — it has not shipped to prod yet, and this closes it before the `develop → main` cascade.

## What

`describeRequest` now runs the URL through `redactUrl`, which does two passes:

1. **`redactPathCredential`** — replaces a credential carried as a path segment, driven by `SENSITIVE_PATH_SEGMENTS` (host → segment index; one row today, `api.ceipal.com` → 0). Ceipal passes its page number via axios `params`, so its key never touches the query string and query-only redaction missed it. `CeipalService` already masks the same value with `maskKey`; the shared client was the one place undoing that.
2. **`redactQuery`** — replaces the value of any credential-bearing query key.

```
GET https://api.ceipal.com/REDACTED/job-postings/?page=2 failed 429, retry 1/3 in 1000ms
GET https://api.resumatorapi.com/v1/jobs?company=acme&apikey=REDACTED&page=3 failed 429, retry 1/3 in 1000ms
```

Everything that makes the line worth logging survives — host, path, and ordinary params like `company` and `page`. Both passes split on delimiters rather than parsing a URL, so a relative or malformed target degrades to "unchanged" instead of throwing inside a logging path.

Also corrects the suite's spec label: the work is Spec 5085, not 5084.

## Review history

The path-credential case was caught by Greptile on the first commit and fixed in `ac17c8c9` — see the [inline thread](https://github.com/ever-jobs/ever-jobs/pull/54#discussion_r3789311284). A repo-wide search for other URL builders that interpolate a credential into a path found only Ceipal.

## Tests

12 new cases — each credential key redacted, non-credential params preserved, no-query URL untouched, fragment preserved, Ceipal path key redacted (alone, with a query, and with a port), a bare origin with no key left alone, and a non-Ceipal host's first path segment left untouched. Suite: **17/17 green locally**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)