### PR TITLE
fix(source-ats-flatchr): let the e2e outlast one client timeout

### DIFF
--- a/packages/plugins/source-ats-flatchr/__tests__/flatchr.e2e-spec.ts
+++ b/packages/plugins/source-ats-flatchr/__tests__/flatchr.e2e-spec.ts
@@ -11,6 +11,13 @@
  * Known live tenants used for testing (verified 2026-06-03):
  *   - `companySlug: 'flatchr'`     — Flatchr itself (3 published vacancies)
  *   - `companySlug: 'groupeaudeo'` — Groupe Audeo (2 published vacancies)
+ *
+ * Timeouts: the HTTP client uses a 60s per-request timeout and does not retry
+ * a timeout -- a timeout carries no `error.response.status`, so the retry loop
+ * rethrows after a single attempt. The network tests below must therefore
+ * outlast one full client timeout. At 30s jest killed them first, so upstream
+ * slowness surfaced as a red shard instead of the service catching the error
+ * and returning an empty result with a diagnostic.
  */
 import { Test, TestingModule } from '@nestjs/testing';
 import { FlatchrModule, FlatchrService } from '@ever-jobs/source-ats-flatchr';
@@ -50,7 +57,7 @@ describe('FlatchrService (E2E)', () => {
       expect((job.atsId ?? '').length).toBeGreaterThan(0);
       expect(job.jobUrl).toBeDefined();
     }
-  }, 30000);
+  }, 120000);
 
   it('should return empty results when neither companySlug nor companyUrl is provided', async () => {
     const input = new ScraperInputDto({
@@ -76,7 +83,7 @@ describe('FlatchrService (E2E)', () => {
     expect(response).toBeDefined();
     expect(Array.isArray(response.jobs)).toBe(true);
     expect(response.jobs.length).toBe(0);
-  }, 30000);
+  }, 120000);
 
   it('should respect the resultsWanted limit', async () => {
     const input = new ScraperInputDto({
@@ -90,5 +97,5 @@ describe('FlatchrService (E2E)', () => {
 
     expect(response).toBeDefined();
     expect(response.jobs.length).toBeLessThanOrEqual(2);
-  }, 30000);
+  }, 120000);
 });


### PR DESCRIPTION
## What

Raises the three network-test timeouts in `flatchr.e2e-spec.ts` from `30000` to `120000`, plus a docblock note explaining why. Test-only — no runtime code changes.

## Why

`Test (Source Scrapers 5/6)` failed on `main` (run [32373416277](https://github.com/ever-jobs/ever-jobs/actions/runs/32373416277)) with three 30s jest timeouts against `careers.flatchr.io`.

**Not a regression:**

| Check | Result |
|---|---|
| Same shard, same code, 4h earlier (run 32354077844) | passed |
| Did Spec 1686 touch flatchr? | no |
| What Spec 1685 changed here | one line *inside the catch block* — runs only after an error |
| Suite locally | 4/4 passed |

**The actual cause:** the test timeout was shorter than a *single request's own* timeout. The plugin builds its client with `timeout: input.requestTimeout`, whose DTO default is `60` (seconds). A timeout is never retried — the retry loop gates on `error.response.status`, and a timeout carries none. So a hung host burns 60s in one attempt, and jest killed the test at 30s before the service could catch the error and return an empty result with a diagnostic.

The plugin was already degrading gracefully. Only the test was too impatient to let it.

## Why 120000 and not 60000

Measured rather than assumed — an 8s client against an unroutable host:

```
PROOF elapsed=8083ms error=timeout of 8000ms exceeded
```

One attempt, not the ~32s three retries would have cost. So at the real 60s default a hung request takes ~60s, and the existing 60s slow-host tier would be a race. `120000` is already this file's effective ceiling via `jest.config.js` `testTimeout: 120_000`, so it adds no new magic number — it just stops tightening below the repo default.

Cost on a healthy host is unchanged (measured 1.5s / 9.7s / 2.4s). The larger budget is only spent when the host actually hangs, and it converts that from a red shard into a pass that exercises the graceful-degradation path.

## Scope

Deliberately this one spec. **446 other ATS e2e tests across 128 specs (576 counting all plugin e2e) carry the same `30000`** and the same argument applies to every one of them — but flatchr is the only one observed flaking. A 576-test sweep would be unreviewable and should be evidence-driven, so it is reported here rather than bundled in.

## Verification

- flatchr suite 4/4 green
- `tsc --noEmit` 0 errors
- `eslint` clean, `lint:docs` clean
- committed blob verified LF (no autocrlf churn), diff is 10 insertions / 3 deletions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
