### PR TITLE
fix(common,plugins): two HTTP clients asked for a 2.8-hour timeout

### DIFF
--- a/packages/common/__tests__/http-client.spec.ts
+++ b/packages/common/__tests__/http-client.spec.ts
@@ -11,6 +11,7 @@ jest.mock('axios', () => ({
   },
 }));
 
+import axios from 'axios';
 import { HttpClient } from '../src/http/http-client';
 import { runWithRequestId } from '../src/context';
 
@@ -244,5 +245,53 @@ describe('HttpClient retry log URL redaction', () => {
     const line = await warnLineFor('https://api.ceipal.com/');
 
     expect(line).toContain('GET https://api.ceipal.com/ failed 429');
+  });
+});
+
+/**
+ * `HttpClientOptions` mixes units -- `timeout` is seconds while `retryDelay` and
+ * `retryMaxDelay` are milliseconds -- and only the rate-delay pair said so. Two
+ * plugins had already written `timeout: 10000` meaning 10s and silently got
+ * ~2.8 hours, which turns a hung host into a request that can only ever be
+ * killed from outside. These pin the contract so a "helpful" unit change to
+ * either side breaks loudly instead of silently.
+ */
+describe('HttpClientOptions unit contract', () => {
+  const created = () => (axios.create as jest.Mock).mock.calls.at(-1)![0];
+
+  beforeEach(() => (axios.create as jest.Mock).mockClear());
+
+  it('reads timeout as SECONDS and hands axios milliseconds', () => {
+    new HttpClient({ timeout: 10 });
+
+    expect(created().timeout).toBe(10_000);
+  });
+
+  it('defaults to 60 seconds when timeout is omitted', () => {
+    new HttpClient({});
+
+    expect(created().timeout).toBe(60_000);
+  });
+
+  it('shows why `timeout: 10000` is the bug it does not look like', () => {
+    new HttpClient({ timeout: 10_000 });
+
+    // 10_000 seconds -- nearly three hours, not the ten seconds it reads as.
+    expect(created().timeout).toBe(10_000_000);
+    expect(created().timeout).toBeGreaterThan(2 * 60 * 60 * 1000);
+  });
+
+  it('reads rateDelayMin/Max as SECONDS', () => {
+    const client = new HttpClient({ rateDelayMin: 2, rateDelayMax: 3 });
+
+    expect((client as any).rateDelayMin).toBe(2000);
+    expect((client as any).rateDelayMax).toBe(3000);
+  });
+
+  it('reads retryDelay and retryMaxDelay as MILLISECONDS, unlike timeout', () => {
+    const client = new HttpClient({ retryDelay: 1500, retryMaxDelay: 20_000 });
+
+    expect((client as any).retryDelay).toBe(1500);
+    expect((client as any).retryMaxDelay).toBe(20_000);
   });
 });

--- a/packages/common/src/http/http-client.ts
+++ b/packages/common/src/http/http-client.ts
@@ -38,9 +38,16 @@ export interface HttpClientOptions {
   caCert?: string;
   userAgent?: string;
   retries?: number;
+  /** Base backoff between retries, in MILLISECONDS (default 1000). */
   retryDelay?: number;
   retryBackoff?: 'linear' | 'exponential';
+  /** Ceiling on any single retry wait, in MILLISECONDS (default 30000). */
   retryMaxDelay?: number;
+  /**
+   * Per-request timeout in SECONDS (default 60) -- NOT milliseconds. It is
+   * multiplied by 1000 below, so `timeout: 10000` asks for ~2.8 hours rather
+   * than 10 seconds. The retry delays above are milliseconds; this one is not.
+   */
   timeout?: number;
   /** Minimum delay between requests in seconds (rate limiting) */
   rateDelayMin?: number;

--- a/packages/plugins/source-francetravail/src/francetravail.constants.ts
+++ b/packages/plugins/source-francetravail/src/francetravail.constants.ts
@@ -2,6 +2,12 @@ export const FRANCETRAVAIL_API_URL = 'https://api.francetravail.io/partenaire/of
 export const FRANCETRAVAIL_TOKEN_URL = 'https://entreprise.francetravail.fr/connexion/oauth2/access_token?realm=/partenaire';
 export const FRANCETRAVAIL_DEFAULT_RESULTS = 25;
 export const FRANCETRAVAIL_MAX_RESULTS = 50;
+/**
+ * Auth-token fetch budget, in SECONDS -- createHttpClient multiplies by 1000.
+ * Spelled out in the name because the option itself is unit-ambiguous.
+ */
+export const FRANCETRAVAIL_TOKEN_TIMEOUT_SECONDS = 10;
+
 export const FRANCETRAVAIL_HEADERS: Record<string, string> = {
   Accept: 'application/json',
   'User-Agent': 'EverJobs/1.0',

--- a/packages/plugins/source-francetravail/src/francetravail.service.ts
+++ b/packages/plugins/source-francetravail/src/francetravail.service.ts
@@ -24,6 +24,7 @@ import {
   FRANCETRAVAIL_HEADERS,
   FRANCETRAVAIL_DEFAULT_RESULTS,
   FRANCETRAVAIL_MAX_RESULTS,
+  FRANCETRAVAIL_TOKEN_TIMEOUT_SECONDS,
 } from './francetravail.constants';
 import { FranceTravailTokenResponse, FranceTravailSearchResponse, FranceTravailOffer } from './francetravail.types';
 
@@ -131,7 +132,7 @@ export class FranceTravailService implements IScraper {
     }
 
     try {
-      const client = createHttpClient({ timeout: 10000 });
+      const client = createHttpClient({ timeout: FRANCETRAVAIL_TOKEN_TIMEOUT_SECONDS });
       client.setHeaders({ 'Content-Type': 'application/x-www-form-urlencoded' });
 
       const body = new URLSearchParams({

--- a/packages/plugins/source-navjobs/src/navjobs.constants.ts
+++ b/packages/plugins/source-navjobs/src/navjobs.constants.ts
@@ -1,6 +1,12 @@
 export const NAVJOBS_FEED_URL = 'https://pam-stilling-feed.nav.no/api/v1/feed';
 export const NAVJOBS_PUBLIC_TOKEN_URL = 'https://pam-stilling-feed.nav.no/api/publicToken';
 export const NAVJOBS_DEFAULT_RESULTS = 25;
+/**
+ * Auth-token fetch budget, in SECONDS -- createHttpClient multiplies by 1000.
+ * Spelled out in the name because the option itself is unit-ambiguous.
+ */
+export const NAVJOBS_TOKEN_TIMEOUT_SECONDS = 10;
+
 export const NAVJOBS_HEADERS: Record<string, string> = {
   Accept: 'application/json',
   'User-Agent': 'EverJobs/1.0',

--- a/packages/plugins/source-navjobs/src/navjobs.service.ts
+++ b/packages/plugins/source-navjobs/src/navjobs.service.ts
@@ -18,7 +18,7 @@ import {
   extractEmails,
   toDateOnly,
 } from '@ever-jobs/common';
-import { NAVJOBS_FEED_URL, NAVJOBS_PUBLIC_TOKEN_URL, NAVJOBS_HEADERS, NAVJOBS_DEFAULT_RESULTS } from './navjobs.constants';
+import { NAVJOBS_FEED_URL, NAVJOBS_PUBLIC_TOKEN_URL, NAVJOBS_HEADERS, NAVJOBS_DEFAULT_RESULTS, NAVJOBS_TOKEN_TIMEOUT_SECONDS } from './navjobs.constants';
 import { NavJobsFeedResponse, NavJobsFeedItem } from './navjobs.types';
 
 @SourcePlugin({
@@ -98,7 +98,7 @@ export class NavJobsService implements IScraper {
     if (this.cachedPublicToken) return this.cachedPublicToken;
 
     try {
-      const client = createHttpClient({ timeout: 10000 });
+      const client = createHttpClient({ timeout: NAVJOBS_TOKEN_TIMEOUT_SECONDS });
       const response = await client.get(NAVJOBS_PUBLIC_TOKEN_URL);
       this.cachedPublicToken = response.data as string;
       this.logger.log('NAV Jobs public token obtained');


### PR DESCRIPTION
## What

Two plugins asked their HTTP client for a **~2.8 hour** timeout when they meant 10 seconds, because `HttpClientOptions.timeout` is in **seconds**, not milliseconds.

```ts
// HttpClient constructor
timeout: (options.timeout ?? 60) * 1000,   // seconds in, milliseconds out
```

```ts
// packages/plugins/source-navjobs/src/navjobs.service.ts:101       (fetchPublicToken)
// packages/plugins/source-francetravail/src/francetravail.service.ts:134  (getAccessToken)
const client = createHttpClient({ timeout: 10000 });   // = 10,000,000 ms
```

Both are **auth-token fetches**, so against a hung token endpoint neither could ever fail fast. In CI that is a test only jest can kill; in the 1,800-way fan-out it is a worker parked on a single source.

## Why it happened

The interface invited it. Of its five numeric options the units are mixed, and only one pair said so:

| Option | Unit | Was documented? |
|---|---|---|
| `timeout` | **seconds** | ✗ |
| `retryDelay` | milliseconds | ✗ |
| `retryMaxDelay` | milliseconds | ✗ |
| `rateDelayMin` / `rateDelayMax` | seconds | ✓ |

All five are documented now, and the two call sites use named `*_TOKEN_TIMEOUT_SECONDS` constants — the house pattern, already used by **146** plugins — so the unit travels with the value.

## This is not the cause of the flake it was found under

Found while diagnosing `Test (Source Scrapers 6/6)` going red on `develop` (run [32415597075](https://github.com/ever-jobs/ever-jobs/actions/runs/32415597075)). Per the evidence chain:

| Check | Result |
|---|---|
| Did a recent release touch `source-navjobs`? | no |
| Shard 6/6 in the three previous runs | passed, passed, passed |
| Suite locally | 2/2 passed, ~1.3s |
| Token endpoint latency now | 0.62s / 0.84s / 0.70s |

So the red X was upstream slowness. **This PR is the reason navjobs could not degrade gracefully when that happened**, not the trigger.

## False positives checked before changing anything

`client.get(url, { timeout: 60000 })` in `source-bdjobs` is a **per-request axios config**, which really is milliseconds — `HttpClient.get` spreads it straight into the axios request. That one is correct and untouched. Those are the only literal timeouts above 300 in non-test code.

## Verification

- **5 new tests** pin the contract from both sides, including one asserting that `timeout: 10000` really does mean ~2.8 hours, so the trap stays visible instead of becoming folklore.
- **Mutation-checked**: rewriting the conversion to `options.timeout ?? 60000` — exactly what a careless unit "cleanup" would do — fails 2 of them.
- `http-client` **27/27**, `navjobs` + `francetravail` **4/4**, `tsc --noEmit` **0 errors**.
- Per-file CRLF and BOM preserved (service files carry a BOM, constants files do not); diff is 72 insertions / 3 deletions with no EOL churn.

## Noted, not fixed here

`source-navjobs` logs a `401` from the feed **on the unmodified revision too**, so it is probably returning nothing in production. Worth its own look — since Spec 1678 it at least reports `blocked` rather than `empty`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
