### PR TITLE
chore: cascade stage -> main (Verdaccio configure-registry in CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,14 @@ jobs:
           node-version: 20.x
           cache: npm
 
+      - name: Configure Registry
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@9459d29e9a3859740348bb445dfe885cae83fc88
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
+
       - name: Install dependencies
         run: npm ci
 
@@ -51,6 +59,14 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
+
+      - name: Configure Registry
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@9459d29e9a3859740348bb445dfe885cae83fc88
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
 
       - name: Install dependencies
         run: npm ci
@@ -85,6 +101,14 @@ jobs:
           node-version: 20.x
           cache: npm
 
+      - name: Configure Registry
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@9459d29e9a3859740348bb445dfe885cae83fc88
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
+
       - name: Install dependencies
         run: npm ci
 
@@ -107,6 +131,14 @@ jobs:
         with:
           node-version: 20.x
           cache: npm
+
+      - name: Configure Registry
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@9459d29e9a3859740348bb445dfe885cae83fc88
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_8 != '' }}
 
       - name: Install dependencies
         run: npm ci
@@ -159,6 +191,14 @@ jobs:
           node-version: 20.x
           cache: npm
 
+      - name: Configure Registry
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@9459d29e9a3859740348bb445dfe885cae83fc88
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
+
       - name: Install dependencies
         run: npm ci
 
@@ -182,6 +222,14 @@ jobs:
         with:
           node-version: 20.x
           cache: npm
+
+      - name: Configure Registry
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@9459d29e9a3859740348bb445dfe885cae83fc88
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_4 != '' }}
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           cache: npm
 
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@9459d29e9a3859740348bb445dfe885cae83fc88
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
         with:
           verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
           verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
@@ -61,7 +61,7 @@ jobs:
           cache: npm
 
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@9459d29e9a3859740348bb445dfe885cae83fc88
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
         with:
           verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
           verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
@@ -102,7 +102,7 @@ jobs:
           cache: npm
 
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@9459d29e9a3859740348bb445dfe885cae83fc88
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
         with:
           verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
           verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
@@ -133,7 +133,7 @@ jobs:
           cache: npm
 
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@9459d29e9a3859740348bb445dfe885cae83fc88
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
         with:
           verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
           verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
@@ -192,7 +192,7 @@ jobs:
           cache: npm
 
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@9459d29e9a3859740348bb445dfe885cae83fc88
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
         with:
           verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
           verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
@@ -224,7 +224,7 @@ jobs:
           cache: npm
 
       - name: Configure Registry
-        uses: ever-co/ever-gauzy/.github/actions/configure-registry@9459d29e9a3859740348bb445dfe885cae83fc88
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
         with:
           verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
           verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}

--- a/packages/common/__tests__/http-client.spec.ts
+++ b/packages/common/__tests__/http-client.spec.ts
@@ -11,6 +11,7 @@ jest.mock('axios', () => ({
   },
 }));
 
+import axios from 'axios';
 import { HttpClient } from '../src/http/http-client';
 import { runWithRequestId } from '../src/context';
 
@@ -244,5 +245,53 @@ describe('HttpClient retry log URL redaction', () => {
     const line = await warnLineFor('https://api.ceipal.com/');
 
     expect(line).toContain('GET https://api.ceipal.com/ failed 429');
+  });
+});
+
+/**
+ * `HttpClientOptions` mixes units -- `timeout` is seconds while `retryDelay` and
+ * `retryMaxDelay` are milliseconds -- and only the rate-delay pair said so. Two
+ * plugins had already written `timeout: 10000` meaning 10s and silently got
+ * ~2.8 hours, which turns a hung host into a request that can only ever be
+ * killed from outside. These pin the contract so a "helpful" unit change to
+ * either side breaks loudly instead of silently.
+ */
+describe('HttpClientOptions unit contract', () => {
+  const created = () => (axios.create as jest.Mock).mock.calls.at(-1)![0];
+
+  beforeEach(() => (axios.create as jest.Mock).mockClear());
+
+  it('reads timeout as SECONDS and hands axios milliseconds', () => {
+    new HttpClient({ timeout: 10 });
+
+    expect(created().timeout).toBe(10_000);
+  });
+
+  it('defaults to 60 seconds when timeout is omitted', () => {
+    new HttpClient({});
+
+    expect(created().timeout).toBe(60_000);
+  });
+
+  it('shows why `timeout: 10000` is the bug it does not look like', () => {
+    new HttpClient({ timeout: 10_000 });
+
+    // 10_000 seconds -- nearly three hours, not the ten seconds it reads as.
+    expect(created().timeout).toBe(10_000_000);
+    expect(created().timeout).toBeGreaterThan(2 * 60 * 60 * 1000);
+  });
+
+  it('reads rateDelayMin/Max as SECONDS', () => {
+    const client = new HttpClient({ rateDelayMin: 2, rateDelayMax: 3 });
+
+    expect((client as any).rateDelayMin).toBe(2000);
+    expect((client as any).rateDelayMax).toBe(3000);
+  });
+
+  it('reads retryDelay and retryMaxDelay as MILLISECONDS, unlike timeout', () => {
+    const client = new HttpClient({ retryDelay: 1500, retryMaxDelay: 20_000 });
+
+    expect((client as any).retryDelay).toBe(1500);
+    expect((client as any).retryMaxDelay).toBe(20_000);
   });
 });

--- a/packages/common/src/http/http-client.ts
+++ b/packages/common/src/http/http-client.ts
@@ -38,9 +38,16 @@ export interface HttpClientOptions {
   caCert?: string;
   userAgent?: string;
   retries?: number;
+  /** Base backoff between retries, in MILLISECONDS (default 1000). */
   retryDelay?: number;
   retryBackoff?: 'linear' | 'exponential';
+  /** Ceiling on any single retry wait, in MILLISECONDS (default 30000). */
   retryMaxDelay?: number;
+  /**
+   * Per-request timeout in SECONDS (default 60) -- NOT milliseconds. It is
+   * multiplied by 1000 below, so `timeout: 10000` asks for ~2.8 hours rather
+   * than 10 seconds. The retry delays above are milliseconds; this one is not.
+   */
   timeout?: number;
   /** Minimum delay between requests in seconds (rate limiting) */
   rateDelayMin?: number;

--- a/packages/plugins/source-ats-flatchr/__tests__/flatchr.e2e-spec.ts
+++ b/packages/plugins/source-ats-flatchr/__tests__/flatchr.e2e-spec.ts
@@ -11,6 +11,13 @@
  * Known live tenants used for testing (verified 2026-06-03):
  *   - `companySlug: 'flatchr'`     — Flatchr itself (3 published vacancies)
  *   - `companySlug: 'groupeaudeo'` — Groupe Audeo (2 published vacancies)
+ *
+ * Timeouts: the HTTP client uses a 60s per-request timeout and does not retry
+ * a timeout -- a timeout carries no `error.response.status`, so the retry loop
+ * rethrows after a single attempt. The network tests below must therefore
+ * outlast one full client timeout. At 30s jest killed them first, so upstream
+ * slowness surfaced as a red shard instead of the service catching the error
+ * and returning an empty result with a diagnostic.
  */
 import { Test, TestingModule } from '@nestjs/testing';
 import { FlatchrModule, FlatchrService } from '@ever-jobs/source-ats-flatchr';
@@ -50,7 +57,7 @@ describe('FlatchrService (E2E)', () => {
       expect((job.atsId ?? '').length).toBeGreaterThan(0);
       expect(job.jobUrl).toBeDefined();
     }
-  }, 30000);
+  }, 120000);
 
   it('should return empty results when neither companySlug nor companyUrl is provided', async () => {
     const input = new ScraperInputDto({
@@ -76,7 +83,7 @@ describe('FlatchrService (E2E)', () => {
     expect(response).toBeDefined();
     expect(Array.isArray(response.jobs)).toBe(true);
     expect(response.jobs.length).toBe(0);
-  }, 30000);
+  }, 120000);
 
   it('should respect the resultsWanted limit', async () => {
     const input = new ScraperInputDto({
@@ -90,5 +97,5 @@ describe('FlatchrService (E2E)', () => {
 
     expect(response).toBeDefined();
     expect(response.jobs.length).toBeLessThanOrEqual(2);
-  }, 30000);
+  }, 120000);
 });

--- a/packages/plugins/source-francetravail/src/francetravail.constants.ts
+++ b/packages/plugins/source-francetravail/src/francetravail.constants.ts
@@ -2,6 +2,12 @@ export const FRANCETRAVAIL_API_URL = 'https://api.francetravail.io/partenaire/of
 export const FRANCETRAVAIL_TOKEN_URL = 'https://entreprise.francetravail.fr/connexion/oauth2/access_token?realm=/partenaire';
 export const FRANCETRAVAIL_DEFAULT_RESULTS = 25;
 export const FRANCETRAVAIL_MAX_RESULTS = 50;
+/**
+ * Auth-token fetch budget, in SECONDS -- createHttpClient multiplies by 1000.
+ * Spelled out in the name because the option itself is unit-ambiguous.
+ */
+export const FRANCETRAVAIL_TOKEN_TIMEOUT_SECONDS = 10;
+
 export const FRANCETRAVAIL_HEADERS: Record<string, string> = {
   Accept: 'application/json',
   'User-Agent': 'EverJobs/1.0',

--- a/packages/plugins/source-francetravail/src/francetravail.service.ts
+++ b/packages/plugins/source-francetravail/src/francetravail.service.ts
@@ -24,6 +24,7 @@ import {
   FRANCETRAVAIL_HEADERS,
   FRANCETRAVAIL_DEFAULT_RESULTS,
   FRANCETRAVAIL_MAX_RESULTS,
+  FRANCETRAVAIL_TOKEN_TIMEOUT_SECONDS,
 } from './francetravail.constants';
 import { FranceTravailTokenResponse, FranceTravailSearchResponse, FranceTravailOffer } from './francetravail.types';
 
@@ -131,7 +132,7 @@ export class FranceTravailService implements IScraper {
     }
 
     try {
-      const client = createHttpClient({ timeout: 10000 });
+      const client = createHttpClient({ timeout: FRANCETRAVAIL_TOKEN_TIMEOUT_SECONDS });
       client.setHeaders({ 'Content-Type': 'application/x-www-form-urlencoded' });
 
       const body = new URLSearchParams({

--- a/packages/plugins/source-navjobs/src/navjobs.constants.ts
+++ b/packages/plugins/source-navjobs/src/navjobs.constants.ts
@@ -1,6 +1,12 @@
 export const NAVJOBS_FEED_URL = 'https://pam-stilling-feed.nav.no/api/v1/feed';
 export const NAVJOBS_PUBLIC_TOKEN_URL = 'https://pam-stilling-feed.nav.no/api/publicToken';
 export const NAVJOBS_DEFAULT_RESULTS = 25;
+/**
+ * Auth-token fetch budget, in SECONDS -- createHttpClient multiplies by 1000.
+ * Spelled out in the name because the option itself is unit-ambiguous.
+ */
+export const NAVJOBS_TOKEN_TIMEOUT_SECONDS = 10;
+
 export const NAVJOBS_HEADERS: Record<string, string> = {
   Accept: 'application/json',
   'User-Agent': 'EverJobs/1.0',

--- a/packages/plugins/source-navjobs/src/navjobs.service.ts
+++ b/packages/plugins/source-navjobs/src/navjobs.service.ts
@@ -18,7 +18,7 @@ import {
   extractEmails,
   toDateOnly,
 } from '@ever-jobs/common';
-import { NAVJOBS_FEED_URL, NAVJOBS_PUBLIC_TOKEN_URL, NAVJOBS_HEADERS, NAVJOBS_DEFAULT_RESULTS } from './navjobs.constants';
+import { NAVJOBS_FEED_URL, NAVJOBS_PUBLIC_TOKEN_URL, NAVJOBS_HEADERS, NAVJOBS_DEFAULT_RESULTS, NAVJOBS_TOKEN_TIMEOUT_SECONDS } from './navjobs.constants';
 import { NavJobsFeedResponse, NavJobsFeedItem } from './navjobs.types';
 
 @SourcePlugin({
@@ -98,7 +98,7 @@ export class NavJobsService implements IScraper {
     if (this.cachedPublicToken) return this.cachedPublicToken;
 
     try {
-      const client = createHttpClient({ timeout: 10000 });
+      const client = createHttpClient({ timeout: NAVJOBS_TOKEN_TIMEOUT_SECONDS });
       const response = await client.get(NAVJOBS_PUBLIC_TOKEN_URL);
       this.cachedPublicToken = response.data as string;
       this.logger.log('NAV Jobs public token obtained');


### PR DESCRIPTION
Promotes stage to main whole, per the standard cascade (no cherry-picks). Carries the pinned shared configure-registry (Verdaccio) CI change verified on develop. 🤖 Generated with [Claude Code](https://claude.com/claude-code)